### PR TITLE
Use the CDN for Bulma vs the gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,6 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
-gem 'bulma-rails', '~> 0.7'
-
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,8 +60,6 @@ GEM
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
-    bulma-rails (0.7.5)
-      sassc (~> 2.0)
     byebug (11.0.1)
     capistrano (3.11.0)
       airbrussh (>= 1.0.0)
@@ -224,9 +222,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.0.1)
-      ffi (~> 1.9)
-      rake
     shoulda-matchers (4.1.1)
       activesupport (>= 4.2.0)
     sprockets (3.7.2)
@@ -264,7 +259,6 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
-  bulma-rails (~> 0.7)
   byebug
   capistrano (~> 3.11)
   capistrano-bundler (~> 1.6)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,5 +13,3 @@
  *= require_tree .
  *= require_self
  */
-
-@import "bulma";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.5/css/bulma.min.css">
+
     <%= stylesheet_link_tag    'application', media: 'all' %>
   </head>
 


### PR DESCRIPTION

### Description
Having asset compilation issues with the Bulma ruby gem.  Easier to just use the CDN.

### Type of change
* Bug fix (non-breaking change which fixes an issue)