### PR TITLE
Change mortality tracking headers

### DIFF
--- a/app/models/mortality_tracking.rb
+++ b/app/models/mortality_tracking.rb
@@ -2,15 +2,19 @@ class MortalityTracking < ApplicationRecord
   include Raw
 
   HEADERS = {
-    COHORT: "cohort",
-    SHL_CASE_NUMBER: "shl_case_number",
-    SHELL_CONTAINER: "shell_container",
-    ANIMAL_LOCATION: "animal_location",
-    APPROXIMATION: "approximation",
-    PROCESSED_BY_SHL: "processed_by_shl",
-    INITIALS: "initials",
-    TAGS: "tags",
-    COMMENTS: "comments"
+    MORTALITY_DATE: "Mortality_date",
+    COHORT: "Cohort",
+    SHL_CASE_NUMBER: "SHL number",
+    SPAWNING_DATE: "Spawning_date",
+    SHELL_BOX: "Shell_box",
+    SHELL_CONTAINER: "Shell_container",
+    ANIMAL_LOCATION: "Animal_location",
+    NUMBER_MORTS: "\# Morts",
+    APPROXIMATION:"Approximation?",
+    PROCESSED_BY_SHL: "Processed by SHL?",
+    INITIALS: "Initials",
+    TAGS: "Tag(s)",
+    COMMENTS: "Comments"
   }
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,6 +52,8 @@ ActiveRecord::Schema.define(version: 2019_07_27_201619) do
     t.string "initials"
     t.string "tags"
     t.string "comments"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "processed_file_id"
   end
 
@@ -137,7 +139,7 @@ ActiveRecord::Schema.define(version: 2019_07_27_201619) do
     t.decimal "growout_trough"
     t.decimal "length"
     t.decimal "mass"
-    t.string "gonad_score"
+    t.decimal "gonad_score"
     t.string "predicted_sex"
     t.text "notes"
     t.datetime "created_at", null: false

--- a/spec/models/mortality_tracking_spec.rb
+++ b/spec/models/mortality_tracking_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe MortalityTracking, type: :model do
+  let(:mortality_tracking) { FactoryBot.create :mortality_tracking }
+
+  describe 'structure' do
+    it { is_expected.to have_db_column :raw }
+    it { is_expected.to have_db_column :mortality_date }
+    it { is_expected.to have_db_column :cohort }
+    it { is_expected.to have_db_column :shl_case_number }
+    it { is_expected.to have_db_column :spawning_date }
+    it { is_expected.to have_db_column :shell_box }
+    it { is_expected.to have_db_column :shell_container }
+    it { is_expected.to have_db_column :animal_location }
+    it { is_expected.to have_db_column :number_morts }
+    it { is_expected.to have_db_column :approximation }
+    it { is_expected.to have_db_column :processed_by_shl }
+    it { is_expected.to have_db_column :initials }
+    it { is_expected.to have_db_column :tags }
+    it { is_expected.to have_db_column :comments }
+
+    describe 'it only has 16 columns' do
+      it { expect(MortalityTracking.columns.count).to eq 16 }
+    end
+  end
+end

--- a/spec/models/pedigree_spec.rb
+++ b/spec/models/pedigree_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Pedigree, type: :model do
     it { is_expected.to have_db_column :seperate_cross_within_cohort }
 
     describe 'it only has 10 columns' do
-      it { expect(Pedigree.columns.count).to eq 10 }
+      it { expect(Pedigree.columns.count).to eq 11 }
     end
   end
 end

--- a/spec/models/population_estimate_spec.rb
+++ b/spec/models/population_estimate_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PopulationEstimate, type: :model do
     it { is_expected.to have_db_column :notes }
 
     describe 'it only has 11 columns' do
-      it { expect(PopulationEstimate.columns.count).to eq 11 }
+      it { expect(PopulationEstimate.columns.count).to eq 12 }
     end
   end
 end

--- a/spec/models/spawning_success_spec.rb
+++ b/spec/models/spawning_success_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SpawningSuccess, type: :model do
     it { is_expected.to have_db_column :nbr_of_eggs_spawned }
 
     describe 'it only has 10 columns' do
-      it { expect(SpawningSuccess.columns.count).to eq 10 }
+      it { expect(SpawningSuccess.columns.count).to eq 11 }
     end
   end
 end


### PR DESCRIPTION
### Description
Some of the MortalityTracking model header fields were out of sync with the excel sheets. This branch syncs them up, and they should now be consistent across excel sheet, model, and db (I think).

Also updated tests broken by added processed_file_id column.   

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Unit tested in spec/models/mortality_tracking_spec.rb