### PR TITLE
Add annotate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
 
+  gem 'annotate',                      require: false
   gem 'capistrano',         '~> 3.11', require: false
   gem 'capistrano-bundler', '~> 1.6',  require: false
   gem 'capistrano-rvm',     '~> 0.1',  require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,9 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     airbrussh (1.3.2)
       sshkit (>= 1.6.1, != 1.7.0)
+    annotate (3.0.2)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 13.0)
     arel (9.0.0)
     ast (2.4.0)
     bindex (0.8.1)
@@ -261,6 +264,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  annotate
   bootsnap (>= 1.1.0)
   byebug
   capistrano (~> 3.11)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ This app is still in early stages of development (MVP). We have defined our [MVP
 
 Take a look at the current [Issues](https://github.com/rubyforgood/abalone/issues), which lay out our path to MVP. Feel free to assign one to yourself and take it on! If you have any questions about requirements, post your question in the issue or email Ellen Cornelius at gellinellen@gmail.com.
 
+### Development
+We have included the [Annotate gem](https://github.com/ctran/annotate_models) in this project, for better development experience. It annotates (table attributes) models, model specs, and factories.
+
+The annotate task will run automatically when running migrations. Please see `lib/tasks/auto_annotate_models.rake` for configuration details.
+
+If it does not run automatically, you can run it manually, on the project root dir, with:
+```
+annotate
+```
+Check out their Github page for more running options.
+
 ### The Problem
 Our stakeholder, the Bodega Marine Laboratory, has more data that they can keep track of! They want to have a central data repository for all of their abalone captive breeding data instead of just spreadhseets. It is hard to run reports and anlytics on the data when it's not all in one place.
 

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -1,2 +1,15 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: facilities
+#
+#  id         :bigint           not null, primary key
+#  name       :string
+#  code       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 class Facility < ApplicationRecord
 end

--- a/app/models/mortality_tracking.rb
+++ b/app/models/mortality_tracking.rb
@@ -1,3 +1,29 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: mortality_trackings
+#
+#  id                :bigint           not null, primary key
+#  raw               :boolean          default(TRUE), not null
+#  mortality_date    :date
+#  cohort            :string
+#  shl_case_number   :string
+#  spawning_date     :date
+#  shell_box         :integer
+#  shell_container   :string
+#  animal_location   :string
+#  number_morts      :integer
+#  approximation     :string
+#  processed_by_shl  :string
+#  initials          :string
+#  tags              :string
+#  comments          :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  processed_file_id :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 class MortalityTracking < ApplicationRecord
   include Raw
 

--- a/app/models/pedigree.rb
+++ b/app/models/pedigree.rb
@@ -1,3 +1,22 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: pedigrees
+#
+#  id                           :bigint           not null, primary key
+#  raw                          :boolean          default(TRUE), not null
+#  cohort                       :string
+#  shl_case_number              :string
+#  spawning_date                :date
+#  mother                       :string
+#  father                       :string
+#  seperate_cross_within_cohort :string
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  processed_file_id            :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 class Pedigree < ApplicationRecord
   include Raw
 

--- a/app/models/population_estimate.rb
+++ b/app/models/population_estimate.rb
@@ -1,3 +1,23 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: population_estimates
+#
+#  id                :bigint           not null, primary key
+#  raw               :boolean          default(TRUE), not null
+#  sample_date       :date
+#  shl_case_number   :string
+#  spawning_date     :date
+#  lifestage         :string
+#  abundance         :string
+#  facility          :string
+#  notes             :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  processed_file_id :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 class PopulationEstimate < ApplicationRecord
   include Raw
 

--- a/app/models/processed_file.rb
+++ b/app/models/processed_file.rb
@@ -1,2 +1,19 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: processed_files
+#
+#  id                :bigint           not null, primary key
+#  filename          :string
+#  original_filename :string
+#  category          :string
+#  status            :string
+#  job_stats         :jsonb            not null
+#  job_errors        :text
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 class ProcessedFile < ApplicationRecord
 end

--- a/app/models/spawning_success.rb
+++ b/app/models/spawning_success.rb
@@ -1,3 +1,22 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: spawning_successes
+#
+#  id                  :bigint           not null, primary key
+#  raw                 :boolean          default(TRUE), not null
+#  tag                 :string
+#  shl_case_number     :string
+#  spawning_date       :date
+#  date_attempted      :date
+#  spawning_success    :string
+#  nbr_of_eggs_spawned :decimal(, )
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  processed_file_id   :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 class SpawningSuccess < ApplicationRecord
   include Raw
 

--- a/app/models/tagged_animal_assessment.rb
+++ b/app/models/tagged_animal_assessment.rb
@@ -1,3 +1,30 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: tagged_animal_assessments
+#
+#  id                  :bigint           not null, primary key
+#  raw                 :boolean          default(TRUE), not null
+#  measurement_date    :date
+#  shl_case_number     :string
+#  spawning_date       :date
+#  tag                 :string
+#  from_growout_rack   :string
+#  from_growout_column :string
+#  from_growout_trough :string
+#  to_growout_rack     :string
+#  to_growout_column   :string
+#  to_growout_trough   :string
+#  length              :decimal(, )
+#  gonad_score         :string
+#  predicted_sex       :string
+#  notes               :text
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  processed_file_id   :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 class TaggedAnimalAssessment < ApplicationRecord
   include Raw
 

--- a/app/models/untagged_animal_assessment.rb
+++ b/app/models/untagged_animal_assessment.rb
@@ -1,3 +1,27 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: untagged_animal_assessments
+#
+#  id                :bigint           not null, primary key
+#  raw               :boolean          default(TRUE), not null
+#  measurement_date  :date
+#  cohort            :string
+#  spawning_date     :date
+#  growout_rack      :decimal(, )
+#  growout_column    :string
+#  growout_trough    :decimal(, )
+#  length            :decimal(, )
+#  mass              :decimal(, )
+#  gonad_score       :decimal(, )
+#  predicted_sex     :string
+#  notes             :text
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  processed_file_id :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 class UntaggedAnimalAssessment < ApplicationRecord
   HEADERS = {
     MEASUREMENT_DATE: "Measurement_date",

--- a/app/models/wild_collection.rb
+++ b/app/models/wild_collection.rb
@@ -1,3 +1,32 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: wild_collections
+#
+#  id                                         :bigint           not null, primary key
+#  raw                                        :boolean          default(TRUE), not null
+#  tag                                        :string
+#  collection_date                            :date
+#  general_location                           :string
+#  precise_location                           :string
+#  collection_coodinates                      :point
+#  proximity_to_nearest_neighbor              :string
+#  collection_method_notes                    :string
+#  foot_condition_notes                       :string
+#  collection_depth                           :decimal(, )
+#  length                                     :decimal(, )
+#  weight                                     :decimal(, )
+#  gonad_score                                :string
+#  predicted_sex                              :string
+#  initial_holding_facility                   :string
+#  final_holding_facility_and_date_of_arrival :string
+#  otc_treatment_completion_date              :date
+#  created_at                                 :datetime         not null
+#  updated_at                                 :datetime         not null
+#  processed_file_id                          :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 class WildCollection < ApplicationRecord
   include Raw
 

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,45 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require "annotate"
+
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      "position_in_routes"      => "before",
+      "position_in_class"       => "before",
+      "position_in_test"        => "before",
+      "position_in_fixture"     => "before",
+      "position_in_factory"     => "before",
+      "position_in_serializer"  => "before",
+      "show_foreign_keys"       => "true",
+      "show_indexes"            => "true",
+      "simple_indexes"          => "false",
+      "model_dir"               => "app/models",
+      "include_version"         => "false",
+      "require"                 => "",
+      "exclude_tests"           => "false",
+      "exclude_fixtures"        => "false",
+      "exclude_factories"       => "false",
+      "exclude_serializers"     => "false",
+      "exclude_scaffolds"       => "true",
+      "exclude_controllers"     => "true",
+      "exclude_helpers"         => "true",
+      "ignore_model_sub_dir"    => "false",
+      "ignore_unknown_models"   => "true",
+      "skip_on_db_migrate"      => "false",
+      "format_bare"             => "true",
+      "format_rdoc"             => "false",
+      "format_markdown"         => "false",
+      "sort"                    => "false",
+      "force"                   => "false",
+      "trace"                   => "false",
+      "wrapper_open"            => "rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength",
+      "wrapper_close"           => "rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective"
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/population_estimates.rb
+++ b/spec/factories/population_estimates.rb
@@ -1,3 +1,23 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: population_estimates
+#
+#  id                :bigint           not null, primary key
+#  raw               :boolean          default(TRUE), not null
+#  sample_date       :date
+#  shl_case_number   :string
+#  spawning_date     :date
+#  lifestage         :string
+#  abundance         :string
+#  facility          :string
+#  notes             :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  processed_file_id :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 FactoryBot.define do
   factory :population_estimate do
     sample_date {Time.now}

--- a/spec/factories/processed_files.rb
+++ b/spec/factories/processed_files.rb
@@ -1,3 +1,20 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: processed_files
+#
+#  id                :bigint           not null, primary key
+#  filename          :string
+#  original_filename :string
+#  category          :string
+#  status            :string
+#  job_stats         :jsonb            not null
+#  job_errors        :text
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 FactoryBot.define do
   factory :processed_file do
     filename { "MyString" }

--- a/spec/factories/tagged_animal_assessments.rb
+++ b/spec/factories/tagged_animal_assessments.rb
@@ -1,3 +1,30 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: tagged_animal_assessments
+#
+#  id                  :bigint           not null, primary key
+#  raw                 :boolean          default(TRUE), not null
+#  measurement_date    :date
+#  shl_case_number     :string
+#  spawning_date       :date
+#  tag                 :string
+#  from_growout_rack   :string
+#  from_growout_column :string
+#  from_growout_trough :string
+#  to_growout_rack     :string
+#  to_growout_column   :string
+#  to_growout_trough   :string
+#  length              :decimal(, )
+#  gonad_score         :string
+#  predicted_sex       :string
+#  notes               :text
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  processed_file_id   :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 FactoryBot.define do
   factory :tagged_animal_assessment do
     

--- a/spec/factories/untagged_animal_assessments.rb
+++ b/spec/factories/untagged_animal_assessments.rb
@@ -1,3 +1,27 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: untagged_animal_assessments
+#
+#  id                :bigint           not null, primary key
+#  raw               :boolean          default(TRUE), not null
+#  measurement_date  :date
+#  cohort            :string
+#  spawning_date     :date
+#  growout_rack      :decimal(, )
+#  growout_column    :string
+#  growout_trough    :decimal(, )
+#  length            :decimal(, )
+#  mass              :decimal(, )
+#  gonad_score       :decimal(, )
+#  predicted_sex     :string
+#  notes             :text
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  processed_file_id :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 FactoryBot.define do
   factory :untagged_animal_assessment do
     

--- a/spec/factories/wild_collections.rb
+++ b/spec/factories/wild_collections.rb
@@ -1,3 +1,32 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: wild_collections
+#
+#  id                                         :bigint           not null, primary key
+#  raw                                        :boolean          default(TRUE), not null
+#  tag                                        :string
+#  collection_date                            :date
+#  general_location                           :string
+#  precise_location                           :string
+#  collection_coodinates                      :point
+#  proximity_to_nearest_neighbor              :string
+#  collection_method_notes                    :string
+#  foot_condition_notes                       :string
+#  collection_depth                           :decimal(, )
+#  length                                     :decimal(, )
+#  weight                                     :decimal(, )
+#  gonad_score                                :string
+#  predicted_sex                              :string
+#  initial_holding_facility                   :string
+#  final_holding_facility_and_date_of_arrival :string
+#  otc_treatment_completion_date              :date
+#  created_at                                 :datetime         not null
+#  updated_at                                 :datetime         not null
+#  processed_file_id                          :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 FactoryBot.define do
   factory :wild_collection do
     

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -1,3 +1,16 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: facilities
+#
+#  id         :bigint           not null, primary key
+#  name       :string
+#  code       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 require 'rails_helper'
 
 RSpec.describe Facility, type: :model do

--- a/spec/models/mortality_tracking_spec.rb
+++ b/spec/models/mortality_tracking_spec.rb
@@ -1,3 +1,29 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: mortality_trackings
+#
+#  id                :bigint           not null, primary key
+#  raw               :boolean          default(TRUE), not null
+#  mortality_date    :date
+#  cohort            :string
+#  shl_case_number   :string
+#  spawning_date     :date
+#  shell_box         :integer
+#  shell_container   :string
+#  animal_location   :string
+#  number_morts      :integer
+#  approximation     :string
+#  processed_by_shl  :string
+#  initials          :string
+#  tags              :string
+#  comments          :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  processed_file_id :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 require 'rails_helper'
 
 RSpec.describe MortalityTracking, type: :model do

--- a/spec/models/pedigree_spec.rb
+++ b/spec/models/pedigree_spec.rb
@@ -1,3 +1,22 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: pedigrees
+#
+#  id                           :bigint           not null, primary key
+#  raw                          :boolean          default(TRUE), not null
+#  cohort                       :string
+#  shl_case_number              :string
+#  spawning_date                :date
+#  mother                       :string
+#  father                       :string
+#  seperate_cross_within_cohort :string
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  processed_file_id            :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 require 'rails_helper'
 
 RSpec.describe Pedigree, type: :model do

--- a/spec/models/population_estimate_spec.rb
+++ b/spec/models/population_estimate_spec.rb
@@ -1,3 +1,23 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: population_estimates
+#
+#  id                :bigint           not null, primary key
+#  raw               :boolean          default(TRUE), not null
+#  sample_date       :date
+#  shl_case_number   :string
+#  spawning_date     :date
+#  lifestage         :string
+#  abundance         :string
+#  facility          :string
+#  notes             :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  processed_file_id :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 require 'rails_helper'
 
 RSpec.describe PopulationEstimate, type: :model do

--- a/spec/models/processed_file_spec.rb
+++ b/spec/models/processed_file_spec.rb
@@ -1,3 +1,20 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: processed_files
+#
+#  id                :bigint           not null, primary key
+#  filename          :string
+#  original_filename :string
+#  category          :string
+#  status            :string
+#  job_stats         :jsonb            not null
+#  job_errors        :text
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 require 'rails_helper'
 
 RSpec.describe ProcessedFile, type: :model do

--- a/spec/models/spawning_success_spec.rb
+++ b/spec/models/spawning_success_spec.rb
@@ -1,3 +1,22 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: spawning_successes
+#
+#  id                  :bigint           not null, primary key
+#  raw                 :boolean          default(TRUE), not null
+#  tag                 :string
+#  shl_case_number     :string
+#  spawning_date       :date
+#  date_attempted      :date
+#  spawning_success    :string
+#  nbr_of_eggs_spawned :decimal(, )
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  processed_file_id   :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 require 'rails_helper'
 
 RSpec.describe SpawningSuccess, type: :model do

--- a/spec/models/tagged_animal_assessment_spec.rb
+++ b/spec/models/tagged_animal_assessment_spec.rb
@@ -1,3 +1,30 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: tagged_animal_assessments
+#
+#  id                  :bigint           not null, primary key
+#  raw                 :boolean          default(TRUE), not null
+#  measurement_date    :date
+#  shl_case_number     :string
+#  spawning_date       :date
+#  tag                 :string
+#  from_growout_rack   :string
+#  from_growout_column :string
+#  from_growout_trough :string
+#  to_growout_rack     :string
+#  to_growout_column   :string
+#  to_growout_trough   :string
+#  length              :decimal(, )
+#  gonad_score         :string
+#  predicted_sex       :string
+#  notes               :text
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  processed_file_id   :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 require 'rails_helper'
 
 RSpec.describe TaggedAnimalAssessment, type: :model do

--- a/spec/models/untagged_animal_assessment_spec.rb
+++ b/spec/models/untagged_animal_assessment_spec.rb
@@ -1,3 +1,27 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: untagged_animal_assessments
+#
+#  id                :bigint           not null, primary key
+#  raw               :boolean          default(TRUE), not null
+#  measurement_date  :date
+#  cohort            :string
+#  spawning_date     :date
+#  growout_rack      :decimal(, )
+#  growout_column    :string
+#  growout_trough    :decimal(, )
+#  length            :decimal(, )
+#  mass              :decimal(, )
+#  gonad_score       :decimal(, )
+#  predicted_sex     :string
+#  notes             :text
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  processed_file_id :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 require 'rails_helper'
 
 RSpec.describe UntaggedAnimalAssessment, type: :model do

--- a/spec/models/wild_collection_spec.rb
+++ b/spec/models/wild_collection_spec.rb
@@ -1,3 +1,32 @@
+# rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
+# == Schema Information
+#
+# Table name: wild_collections
+#
+#  id                                         :bigint           not null, primary key
+#  raw                                        :boolean          default(TRUE), not null
+#  tag                                        :string
+#  collection_date                            :date
+#  general_location                           :string
+#  precise_location                           :string
+#  collection_coodinates                      :point
+#  proximity_to_nearest_neighbor              :string
+#  collection_method_notes                    :string
+#  foot_condition_notes                       :string
+#  collection_depth                           :decimal(, )
+#  length                                     :decimal(, )
+#  weight                                     :decimal(, )
+#  gonad_score                                :string
+#  predicted_sex                              :string
+#  initial_holding_facility                   :string
+#  final_holding_facility_and_date_of_arrival :string
+#  otc_treatment_completion_date              :date
+#  created_at                                 :datetime         not null
+#  updated_at                                 :datetime         not null
+#  processed_file_id                          :integer
+#
+# rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
+
 require 'rails_helper'
 
 RSpec.describe WildCollection, type: :model do


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->


### Description
I've added this annotate gem: https://github.com/ctran/annotate_models

Purely to ease the development of this project.
I feel this would be a useful addition, as devs won't have to check migration files/or db itself to see what attributes the models have. And as evident from the failing tests, and incorrect attributes for some model factories.

Let me know if this needs more discussions :) I'm also open for suggestions.

### Type of change

<!-- Please delete options that are not relevant. -->

* Development process improvements

### How Has This Been Tested?

Ran complete spec tests to make sure nothing else is broken. There's currently 1 failing test, that is fixed from my other PR.