### PR TITLE
TravisCI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: ruby
+before_install: gem install bundler
+services:
+  - postgresql
+# documentation for why we use these before_script commands for setting up postgres:
+# https://docs.travis-ci.com/user/database-setup/#using-postgresql-in-your-builds
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres
+  - cp config/database.yml.travis config/database.yml

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -1,0 +1,3 @@
+test:
+  adapter: postgresql
+  database: travis_ci_test


### PR DESCRIPTION
Resolves **the CI part** of #079

### Description

I configured the project to use TravisCI for running the test suite on Pull Requests. TravisCI was chosen because it's free, popular, easy to use, and the rubyforgood github organization already has a matching rubyforgood travis account, so getting it set up was very easy.

### Type of change

This change is a maintainer-facing change only, and does not affect the users in any direct fashion.

### How Has This Been Tested?

Travis has already run builds for this branch. Here is the latest: https://travis-ci.org/yarmiganosca/abalone/builds/605669573