### PR TITLE
Simplify CSV import

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,6 +297,7 @@ PLATFORMS
 DEPENDENCIES
   annotate
   bootsnap (>= 1.1.0)
+  byebug
   capistrano (~> 3.11)
   capistrano-bundler (~> 1.6)
   capistrano-rails (~> 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,7 +297,6 @@ PLATFORMS
 DEPENDENCIES
   annotate
   bootsnap (>= 1.1.0)
-  byebug
   capistrano (~> 3.11)
   capistrano-bundler (~> 1.6)
   capistrano-rails (~> 1.4)

--- a/app/controllers/file_uploads_controller.rb
+++ b/app/controllers/file_uploads_controller.rb
@@ -2,12 +2,7 @@ class FileUploadsController < ApplicationController
 
   # The second value for each category entry will be used to determine the job class that processes the data.
   # Ex: Selecting "Spawning Success" in the form will post "SpawningSuccess" and process the data with a SpawningSuccessJob.
-  CATEGORIES = [
-      ['Spawning Success','SpawningSuccess'],
-      ['Tagged Animal Assessment','TaggedAnimalAssessment'],
-      ['Untagged Animal Assessment', 'UntaggedAnimalAssessment'],
-      # ['Wild Collection','WildCollection']
-  ].freeze
+  CATEGORIES = CsvImporter::CATEGORIES.map {|category| [category, category.delete(' ')] }.freeze
 
   def index
     @processed_files = ProcessedFile.all.order(updated_at: :desc).first(20)

--- a/app/controllers/file_uploads_controller.rb
+++ b/app/controllers/file_uploads_controller.rb
@@ -2,14 +2,14 @@ class FileUploadsController < ApplicationController
 
   # The second value for each category entry will be used to determine the job class that processes the data.
   # Ex: Selecting "Spawning Success" in the form will post "SpawningSuccess" and process the data with a SpawningSuccessJob.
-  CATEGORIES = CsvImporter::CATEGORIES.map {|category| [category, category.delete(' ')] }.freeze
+  FILE_UPLOAD_CATEGORIES = CsvImporter::CATEGORIES.map {|category| [category, category.delete(' ')] }.freeze
 
   def index
     @processed_files = ProcessedFile.all.order(updated_at: :desc).first(20)
   end
 
   def new
-    @categories = [['Select One', '']] + CATEGORIES
+    @categories = [['Select One', '']] + FILE_UPLOAD_CATEGORIES
   end
 
   def show_processing_csv_errors
@@ -44,9 +44,8 @@ class FileUploadsController < ApplicationController
   end
 
   def upload
-
     @category = params[:category]
-    if CATEGORIES.map{|label,value| value}.include?(@category)
+    if FILE_UPLOAD_CATEGORIES.map{|label,value| value}.include?(@category)
       uploaded_io = params[:input_file]
       timestamp = Time.new.strftime('%s_%N')
       if uploaded_io

--- a/app/jobs/concerns/import_job.rb
+++ b/app/jobs/concerns/import_job.rb
@@ -18,12 +18,12 @@ module ImportJob
       if validate_headers(full_path)
         import_records(full_path)
         complete_processed_file!
+        remove_file!(filename) unless stats[:rows_not_imported] > 0
       else
         log("Error: #{filename} does not have valid headers. Data not imported!", :error)
         fail_processed_file("Does not have valid headers. Data not imported!")
       end
     end
-    remove_file!(filename) unless stats[:rows_not_imported] > 0
     @processed_file.save
   end
 

--- a/app/jobs/spawning_success_job.rb
+++ b/app/jobs/spawning_success_job.rb
@@ -1,11 +1,3 @@
 class SpawningSuccessJob < ApplicationJob
   include ImportJob
-
-  private
-
-  def translate_attribute_names(attrs)
-    attrs['nbr_of_eggs_spawned'] = attrs.delete('number_of_eggs_spawned_if_female')
-    attrs['shl_case_number']     = attrs.delete('shl_number')
-    attrs
-  end
 end

--- a/app/jobs/untagged_animal_assessment_job.rb
+++ b/app/jobs/untagged_animal_assessment_job.rb
@@ -1,10 +1,3 @@
 class UntaggedAnimalAssessmentJob < ApplicationJob
-
   include ImportJob
-
-  def translate_attribute_names(attrs)
-    attrs['shl_case_number'] = attrs.delete('cohort')
-    attrs
-  end
-
 end

--- a/app/jobs/wild_collection_job.rb
+++ b/app/jobs/wild_collection_job.rb
@@ -1,22 +1,3 @@
 class WildCollectionJob < ApplicationJob
   include ImportJob
-
-  private
-
-  # Translate from csv column name to database column name
-  def translate_attribute_names(attrs)
-    attrs['proximity_to_nearest_neighbor']              = attrs.delete('proximity_to_nearest_neighbor_m')
-    attrs['collection_depth']                           = attrs.delete('collection_depth_m')
-    attrs['collection_coordinates']                     = attrs.delete('collection_coodinates')
-    attrs['final_holding_facility_and_date_of_arrival'] = attrs.delete('final_holding_facility__date_of_arrival')
-
-    attrs
-  end
-
-  def preprocess_attribute_values(attrs)
-    attrs['collection_date'] = Date.strptime(attrs['collection_date'], '%m/%d/%y') rescue nil
-    attrs['otc_treatment_completion_date'] = Date.strptime(attrs['otc_treatment_completion_date'], '%m/%d/%y') rescue nil
-
-    attrs
-  end
 end

--- a/app/lib/csv_importer.rb
+++ b/app/lib/csv_importer.rb
@@ -1,41 +1,56 @@
-module CsvImporter
-  CSV_CATEGORIES = {
-      SPAWNING_SUCCESS: 'Spawning Success',
-      TAGGED_ANIMAL_ASSESSMENT: 'Tagged Animal Assessment',
-      UNTAGGED_ANIMAL_ASSESSMENT: 'Untagged Animal Assessment'
-  }.freeze
+class CsvImporter
+  attr_reader :stats, :model, :filename, :processed_file_id
 
-  class InvalidCsvCategoryError < StandardError; end;
+  CATEGORIES = [
+      'Spawning Success',
+      'Tagged Animal Assessment',
+      'Untagged Animal Assessment',
+      'Wild Collection',
+  ].freeze
+
+  class InvalidCategoryError < StandardError; end;
 
   def self.import(filename, category_name, processed_file_id)
-    csv_category_model = model_from_category(category_name)
-    IOStreams.each_record(filename) do |record|
-      attrs = translate_attribute_names(record, category_name)
-      attrs[:processed_file_id] = processed_file_id
-      csv_row_record = csv_category_model.new(attrs.merge({raw: false}))
-      csv_row_record.cleanse_data! if csv_row_record.respond_to?(:cleanse_data!)
-      csv_row_record.save
+    importer = new(filename, category_name, processed_file_id)
+    importer.process
+    importer.stats
+  end
+
+  def initialize(filename, category_name, processed_file_id)
+    @filename = filename
+    @processed_file_id = processed_file_id
+    @model = model_from_category(category_name)
+
+    @stats = Hash.new(0)
+    @stats[:shl_case_numbers] = Hash.new(0)
+  end
+
+  def process
+    IOStreams.each_record(filename) do |csv_row|
+      csv_row[:processed_file_id] = processed_file_id
+      csv_row[:raw] = false
+      record = model.create_from_csv_data(csv_row)
+      record.cleanse_data! if record.respond_to?(:cleanse_data!)
+      record.save
+      increment_stats(record)
     end
   end
 
-  def self.model_from_category(category_name)
-    case category_name
-    when CSV_CATEGORIES[:SPAWNING_SUCCESS]
-      SpawningSuccess
-    when CSV_CATEGORIES[:TAGGED_ANIMAL_ASSESSMENT]
-      TaggedAnimalAssessment
-    when CSV_CATEGORIES[:UNTAGGED_ANIMAL_ASSESSMENT]
-      UntaggedAnimalAssessment
+  def model_from_category(category_name)
+    if CATEGORIES.include?(category_name)
+      category_name.delete(' ').constantize
     else
-      raise InvalidCsvCategoryError
+      raise InvalidCategoryError
     end
   end
 
-  def self.translate_attribute_names(attrs, category_name)
-    case category_name
-    when CSV_CATEGORIES[:SPAWNING_SUCCESS]
-      attrs['nbr_of_eggs_spawned'] = attrs.delete('number_of_eggs_spawned_if_female')
+  def increment_stats(model)
+    stats[:row_count] += 1
+    if model.persisted?
+      stats[:rows_imported] += 1
+      stats[:shl_case_numbers][model.shl_case_number] += 1 if model.respond_to?(:shl_case_number)
+    else
+      stats[:rows_not_imported] += 1
     end
-    attrs
   end
 end

--- a/app/models/spawning_success.rb
+++ b/app/models/spawning_success.rb
@@ -31,6 +31,12 @@ class SpawningSuccess < ApplicationRecord
 
   validates :shl_case_number, presence: true
 
+  def self.create_from_csv_data(attrs)
+    attrs['nbr_of_eggs_spawned'] = attrs.delete('number_of_eggs_spawned_if_female')
+    attrs['shl_case_number']     = attrs.delete('shl_number')
+    new(attrs)
+  end
+
   # Note: Case is meaningful for spawning_success. n, Y and y mean different things.
   def cleanse_data!
     self.tag = self.tag.to_s&.strip&.upcase

--- a/app/models/tagged_animal_assessment.rb
+++ b/app/models/tagged_animal_assessment.rb
@@ -48,6 +48,10 @@ class TaggedAnimalAssessment < ApplicationRecord
   validates :measurement_date, :shl_case_number, :spawning_date, :tag, :length, presence: true
   validates :length, numericality: true
 
+  def self.create_from_csv_data(attrs)
+    new(attrs)
+  end
+
   def measurement_date=(measurement_date_str)
     return unless measurement_date_str
     write_attribute(:measurement_date, DateTime.strptime(measurement_date_str, '%m/%d/%y'))
@@ -65,5 +69,4 @@ class TaggedAnimalAssessment < ApplicationRecord
   def cleanse_data!
     # Do nothing
   end
-
 end

--- a/app/models/untagged_animal_assessment.rb
+++ b/app/models/untagged_animal_assessment.rb
@@ -48,10 +48,18 @@ class UntaggedAnimalAssessment < ApplicationRecord
   )
   validates :length, numericality: true
 
+  def self.create_from_csv_data(attrs)
+    new(attrs)
+  end
+
   # Cohort is translated to shl_case_number to compute stats.
   # Here we need to transfer it back to be able to store value in the DB.
   def shl_case_number=(value)
     self.cohort = value
+  end
+
+  def shl_case_number
+    self.cohort
   end
 
   def measurement_date=(measurement_date_str)

--- a/app/models/wild_collection.rb
+++ b/app/models/wild_collection.rb
@@ -68,6 +68,17 @@ class WildCollection < ApplicationRecord
   validate :initial_holding_facility_is_valid,
            :final_facility_and_date_of_arrival_is_valid
 
+
+  def self.create_from_csv_data(attrs)
+    attrs['proximity_to_nearest_neighbor']              = attrs.delete('proximity_to_nearest_neighbor_m')
+    attrs['collection_depth']                           = attrs.delete('collection_depth_m')
+    attrs['collection_coordinates']                     = attrs.delete('collection_coodinates')
+    attrs['final_holding_facility_and_date_of_arrival'] = attrs.delete('final_holding_facility__date_of_arrival')
+    attrs['collection_date'] = Date.strptime(attrs['collection_date'], '%m/%d/%y') rescue nil
+    attrs['otc_treatment_completion_date'] = Date.strptime(attrs['otc_treatment_completion_date'], '%m/%d/%y') rescue nil
+    new(attrs)
+  end
+
   def initial_holding_facility_is_valid
     return if initial_holding_facility.blank?
     return if Facility.valid_code?(initial_holding_facility)
@@ -104,4 +115,6 @@ class WildCollection < ApplicationRecord
 
     super(value)
   end
+
+
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,7 +32,7 @@ facilities.each{ |f_name, f_code|  Facility.find_or_create_by(name: f_name, code
 #   end
 # end
 
-current_csv_importers = ['Spawning Success','Tagged Animal Assessment','Untagged Animal Assessment']
+current_csv_importers = CsvImporter::CATEGORIES
 
 Dir["db/sample_data_files/*"].each do |category_dir|
   category_class_name = File.basename(category_dir).titleize


### PR DESCRIPTION
Because the `db/seeds` and the `ImportJob` jobs were both importing CSVs, it made sense to consolidate the business logic of importing CSV data in one place. The `CsvImporter` seems a good place.

* Made `CsvImporter` responsible for doing the actual import

This makes the background jobs a lot simpler by deferring to the importer to do the actual data processing.

`CsvImporter` refactored from a module to a class so that an individual import action is represented by an instance of an importer. A class method `import()` remains that maintains the previous method signature so the existing call sites for CSV import stay the same.

* `CsvImporter::CATEGORIES`

This is a simpler list of the human-readable strings that are the categories of data to import. This is the **One True Place**™ where categories that are importable by CSV are declared. Everywhere that does imports (the import jobs and the seeds) refer to this list to know what's importable.

* Import statistics generation moved to `CsvImporter`

* CSV-to-database-columns translation moved to the models

The `create_from_csv_data()` on the models is now responsible for using a row of CSV data and instantiating a new model ready to be saved to the database. A future improvement to this method could be to perform any data cleansing currently handled by `data_cleanse!()` and save the model to the database.

The `HEADERS` mapping between CSV column names and database column names already lived in the models.  Colocating the mapping and the methods that execute on that mapping should make maintaining them clearer.