### PR TITLE
Store uploaded csv files in database not on disk

### DIFF
--- a/app/jobs/concerns/import_job.rb
+++ b/app/jobs/concerns/import_job.rb
@@ -11,13 +11,12 @@ module ImportJob
   def perform(*args)
     temporary_file_id = args[0]
     temporary_file = TemporaryFile.find(temporary_file_id)
+    initialize_processed_file(temporary_file_id)
     if already_processed?(temporary_file_id)
-      initialize_processed_file(temporary_file_id)
       fail_processed_file("Already processed a file from the same upload event. Data not imported!")
     else
       filename = create_temp_file_on_disk(temporary_file_id)
       full_path = Rails.root.join('storage', filename).to_s
-      initialize_processed_file(temporary_file_id)
 
       if validate_headers(full_path)
         import_records(full_path)

--- a/app/jobs/concerns/import_job.rb
+++ b/app/jobs/concerns/import_job.rb
@@ -9,12 +9,16 @@ module ImportJob
   end
 
   def perform(*args)
-    filename = args[0]
-    full_path = Rails.root.join('storage', filename).to_s
-    initialize_processed_file(filename)
-    if already_processed?(filename)
-      fail_processed_file("Already processed a file with the same name. Data not imported!")
+    temporary_file_id = args[0]
+    temporary_file = TemporaryFile.find(temporary_file_id)
+    if already_processed?(temporary_file_id)
+      initialize_processed_file(temporary_file_id)
+      fail_processed_file("Already processed a file from the same upload event. Data not imported!")
     else
+      filename = create_temp_file_on_disk(temporary_file_id)
+      full_path = Rails.root.join('storage', filename).to_s
+      initialize_processed_file(temporary_file_id)
+
       if validate_headers(full_path)
         import_records(full_path)
         complete_processed_file!
@@ -27,11 +31,20 @@ module ImportJob
     @processed_file.save
   end
 
-  def validate_headers(filename)
-    raise "No input file specified" unless filename
-    headers = CSV.parse(File.read(filename, encoding: 'bom|utf-8'), headers: true)
-      .headers
-      .compact
+  def create_temp_file_on_disk(temporary_file_id)
+    timestamp = Time.new.strftime('%s_%N')
+    filename = [timestamp, temporary_file_id].join('_') + '.csv'
+    File.open(Rails.root.join('storage', filename), 'wb') do |file|
+      file.write TemporaryFile.find(temporary_file_id).contents
+    end
+
+    return filename
+  end
+
+  def validate_headers(full_path)
+    raise "No input file specified" unless full_path
+
+    headers = CSV.parse(File.read(full_path, encoding: 'bom|utf-8'), headers: true).headers.compact
     valid_headers = category_model::HEADERS.values
 
     log("Headers in file: #{headers}", :debug)
@@ -57,9 +70,8 @@ module ImportJob
     ProcessedFile.where(status: ['Processed','Processed with errors'] ).where(original_filename: original_filename(filename)).count > 0
   end
 
-  def initialize_processed_file(filename)
-    @processed_file = ProcessedFile.new(filename: filename,
-                                        original_filename: original_filename(filename),
+  def initialize_processed_file(temporary_file_id)
+    @processed_file = ProcessedFile.new(temporary_file_id: temporary_file_id,
                                         category: category,
                                         status: 'Running')
   end

--- a/app/models/temporary_file.rb
+++ b/app/models/temporary_file.rb
@@ -1,0 +1,2 @@
+class TemporaryFile < ApplicationRecord
+end

--- a/db/migrate/20200109183112_create_temporary_files.rb
+++ b/db/migrate/20200109183112_create_temporary_files.rb
@@ -1,0 +1,9 @@
+class CreateTemporaryFiles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :temporary_files do |t|
+      t.text :contents
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200109184825_add_temporary_file_id_to_processed_files.rb
+++ b/db/migrate/20200109184825_add_temporary_file_id_to_processed_files.rb
@@ -1,0 +1,5 @@
+class AddTemporaryFileIdToProcessedFiles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :processed_files, :temporary_file_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_09_183112) do
+ActiveRecord::Schema.define(version: 2020_01_09_184825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 2020_01_09_183112) do
     t.text "job_errors"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "temporary_file_id"
   end
 
   create_table "spawning_successes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_31_181501) do
+ActiveRecord::Schema.define(version: 2020_01_09_183112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,12 @@ ActiveRecord::Schema.define(version: 2019_10_31_181501) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "processed_file_id"
+  end
+
+  create_table "temporary_files", force: :cascade do |t|
+    t.text "contents"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "untagged_animal_assessments", force: :cascade do |t|

--- a/spec/factories/temporary_files.rb
+++ b/spec/factories/temporary_files.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :temporary_file do
+    
+  end
+end

--- a/spec/features/upload_tagged_animal_assessments_spec.rb
+++ b/spec/features/upload_tagged_animal_assessments_spec.rb
@@ -48,10 +48,12 @@ describe "upload TaggedAnimalAssessment category", type: :feature do
   end
 
   context 'when user upload a CSV that has been already processed' do
+    let(:temporary_file) { create(:temporary_file, contents: '') }
+
     before do
       FactoryBot.create :processed_file,
         status: 'Processed',
-        original_filename: 'Tagged_assessment_12172018 (original).csv'
+        temporary_file_id: temporary_file.id
     end
 
     it "creates new ProcessedFile record with 'Failed' status" do
@@ -59,7 +61,7 @@ describe "upload TaggedAnimalAssessment category", type: :feature do
 
       processed_file = ProcessedFile.where(status: "Failed").first
       expect(ProcessedFile.count).to eq 2
-      expect(processed_file.job_errors).to eq "Already processed a file with the same name. Data not imported!"
+      expect(processed_file.job_errors).to eq "Already processed a file from the same upload event. Data not imported!"
       expect(processed_file.job_stats).to eq({})
       expect(page).to have_content expected_success_message
     end

--- a/spec/features/upload_untagged_animal_assessments_spec.rb
+++ b/spec/features/upload_untagged_animal_assessments_spec.rb
@@ -48,10 +48,12 @@ describe "upload UntaggedAnimalAssessment category", type: :feature do
   end
 
   context 'when user upload a CSV that has been already processed' do
+    let(:temporary_file) { create(:temporary_file, contents: '') }
+
     before do
       FactoryBot.create :processed_file,
         status: 'Processed',
-        original_filename: 'Untagged_assessment_03122018.csv'
+        temporary_file_id: temporary_file.id
     end
 
     it "creates new ProcessedFile record with 'Failed' status" do
@@ -59,7 +61,7 @@ describe "upload UntaggedAnimalAssessment category", type: :feature do
 
       processed_file = ProcessedFile.where(status: "Failed").first
       expect(ProcessedFile.count).to eq 2
-      expect(processed_file.job_errors).to eq "Already processed a file with the same name. Data not imported!"
+      expect(processed_file.job_errors).to eq "Already processed a file from the same upload event. Data not imported!"
       expect(processed_file.job_stats).to eq({})
       expect(page).to have_content expected_success_message
     end

--- a/spec/jobs/wild_collection_job_spec.rb
+++ b/spec/jobs/wild_collection_job_spec.rb
@@ -3,7 +3,5 @@ require "rails_helper"
 RSpec.describe WildCollectionJob do
   let(:filename) { "example_of_wild_collection_data.csv" }
 
-  skip 'Ellen noticed heroku worker cannot process csv saved to disk so will need to change how we move forward' do
-    it_behaves_like "import job"
-  end
+  it_behaves_like "import job"
 end

--- a/spec/jobs/wild_collection_job_spec.rb
+++ b/spec/jobs/wild_collection_job_spec.rb
@@ -3,5 +3,9 @@ require "rails_helper"
 RSpec.describe WildCollectionJob do
   let(:filename) { "example_of_wild_collection_data.csv" }
 
+  before do
+    Rails.application.load_seed if Facility.valid_codes.empty?
+  end
+
   it_behaves_like "import job"
 end

--- a/spec/models/temporary_file_spec.rb
+++ b/spec/models/temporary_file_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TemporaryFile, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/abalone/issues/104

### Description
This PR addresses the problem where because a heroku worker runs on a different app, it cannot access the local disk storage of the webapp, where the csv files live.

To solve that, this PR does the following:
* Instead of taking csv uploads and writing it to disk, shove it into a `TemporaryFile` object.
* When the `ImportJob` runs, grab the contents of that `TemporaryFile` object, write it to disk, and continue as before.

Note: this code change doesn't delete the `TemporaryFile` objects or clean what's on disk - let's open that request as a new low-priority issue.

We might want to add some architectural notes to the README about this, but I'd like for either someone else to do that if it's needed for this PR before merge, or to do it as a separate PR.

### Type of change
* Bug fix (non-breaking change which fixes an issue)
Behavior should be the same locally, but should go from not-working to working in production

### How To Test

When run locally, app behavior should behave as before.  Verify the upload, job runner, and file processing workflow:

- [ ] Upload a valid CSV
- [ ] Make sure your jobs worker is running
- [ ] After the job is run, check if new entries were created
