### PR TITLE
[Issue 112] Create job called by daily cron that deletes processed TemporaryFiles

### DIFF
--- a/app/models/processed_file.rb
+++ b/app/models/processed_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Lint/UnneededCopDisableDirective, Metrics/LineLength
 # == Schema Information
 #
@@ -16,4 +18,5 @@
 # rubocop:enable Metrics/LineLength, Lint/UnneededCopDisableDirective
 
 class ProcessedFile < ApplicationRecord
+  belongs_to :temporary_file, optional: true, inverse_of: :processed_file
 end

--- a/app/models/temporary_file.rb
+++ b/app/models/temporary_file.rb
@@ -1,2 +1,5 @@
+# frozen_string_literal: true
+
 class TemporaryFile < ApplicationRecord
+  has_one :processed_file, inverse_of: :temporary_file
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+namespace :scheduler do
+  desc 'Delete stale temporary files'
+  # This rake task is meant to be run once per day to cleanse temporary files
+  # from the database. It will also log if any temporary files have not been
+  # successfully processed.
+  task delete_stale_temporary_files: :environment do
+    # collect all temporary_files over a week old
+    TemporaryFile.where('created_at < ?', 7.days.ago).each do |file|
+      # check if they have been processed successfully
+      if file.processed_file && file.processed_file.status == 'Processed'
+        # if yes, then we are safe to destroy the file
+        file.destroy
+      else
+        # if no, then we log the file to be handled later
+        warning_message = <<-MESSAGE
+          Warning: TemporaryFile with id #{file.id} is more than
+          7 days old but has not been processed successfully.
+        MESSAGE
+        Rails.logger.warn warning_message
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/scheduler_rake_spec.rb
+++ b/spec/lib/tasks/scheduler_rake_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'scheduler:delete_stale_temporary_files' do
+  include_context 'rake'
+
+  let(:temp_file) do
+    create(:temporary_file, contents: '', created_at: 8.days.ago)
+  end
+
+  it 'deletes a stale temporary file that is successfully processed' do
+    create :processed_file, status: 'Processed', temporary_file_id: temp_file.id
+    expect(TemporaryFile.count).to eq 1
+    subject.invoke
+    expect(TemporaryFile.count).to eq 0
+  end
+
+  it 'does not delete a recent temporary file' do
+    file = create(:temporary_file, contents: '', created_at: 6.days.ago)
+    create :processed_file, status: 'Processed', temporary_file_id: file.id
+    subject.invoke
+    expect(TemporaryFile.count).to eq 1
+  end
+
+  it 'warns about a temporary file that has no processed file' do
+    temp_file
+    subject.invoke
+    expect(TemporaryFile.count).to eq 1
+  end
+
+  it 'warns about a temporary file that was not processed successfully' do
+    create :processed_file, status: 'Failed', temporary_file_id: temp_file.id
+    subject.invoke
+    expect(TemporaryFile.count).to eq 1
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,6 +16,7 @@ Delayed::Worker.delay_jobs = false
 Dir[Rails.root.join("spec", "jobs", "concerns", "**", "*.rb")].each { |f| require f }
 Dir[Rails.root.join("spec", "models", "concerns", "**", "*.rb")].each { |f| require f }
 require 'support/factory_bot'
+require 'support/shared_contexts/rake.rb'
 require './spec/support/file_upload_helpers'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -73,6 +74,8 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :feature
 
   config.include FileUploadHelpers
+
+  config.include_context "rake", include_shared: true
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,24 @@
+require "rake"
+
+shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  # use the text we pass to `describe` to calculate the task we’re going to run
+  let(:task_name) { self.class.top_level_description }
+  # `task_path` is the path to the file itself, relative to `Rails.root`
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  subject         { rake[task_name] }
+
+  # exclude the path to the task we’re testing so we have the task available. 
+  # this only matters when you’re running more than one test on a rake task
+  def loaded_files_excluding_current_rake_file
+    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+
+    # load Rails stack from inside the lib folder
+    Rake::Task.define_task(:environment)
+  end
+end


### PR DESCRIPTION
This PR:
- Resolves #112
- Creates a rake task to delete or warn about stale TemporaryFiles
- Adds a has_one/belongs_to relationship between temporary and processed files
- Adds rspec tests for the new rake task
- Creates a shared context in rspec for testing future rake tasks

Type of change:
New feature (non-breaking change which adds functionality)

Discussion Points:
- On the data side, I noticed there was no relationship between ProcessedFiles and TemporaryFiles in their respective models. I created a has_one/belongs_to relationship between the two for easier lookup in the rake task. Please let me know if this should be one-to-many instead, or if there was a reason to not have a relationship specified in the model.
- From a feature perspective, I didn't see a way for a user to delete a ProcessedFile that failed to upload, and because the rake task currently sends out warnings about these, there may be a large build up of warnings over time. If this is an issue, I could change the rake task to log temporary files that are completely missing a processed file, or I could add a button to let users delete their failed file uploads.