### PR TITLE
✨ Related Operations may be grouped into OperationBatches

### DIFF
--- a/app/models/operation.rb
+++ b/app/models/operation.rb
@@ -1,5 +1,7 @@
 class Operation < ApplicationRecord
   belongs_to :tank
+
+  belongs_to :operation_batch, required: false
   belongs_to :family, required: false
 
   validates :family, presence: true, if: :add_family?

--- a/app/models/operation_batch.rb
+++ b/app/models/operation_batch.rb
@@ -1,0 +1,3 @@
+class OperationBatch < ApplicationRecord
+  has_many :operations
+end

--- a/app/models/tank.rb
+++ b/app/models/tank.rb
@@ -5,4 +5,8 @@ class Tank < ApplicationRecord
   has_many :measurements, through: :measurement_events
 
   has_one :family, required: false
+
+  def empty?
+    family.blank?
+  end
 end

--- a/db/migrate/20200513172140_create_operation_batches.rb
+++ b/db/migrate/20200513172140_create_operation_batches.rb
@@ -1,0 +1,12 @@
+class CreateOperationBatches < ActiveRecord::Migration[5.2]
+  def change
+    create_table :operation_batches do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    change_table :operations do |operations_schema|
+      operations_schema.references :operation_batch
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_06_175333) do
+ActiveRecord::Schema.define(version: 2020_05_13_172140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,6 +112,12 @@ ActiveRecord::Schema.define(version: 2020_05_06_175333) do
     t.integer "processed_file_id"
   end
 
+  create_table "operation_batches", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "operations", force: :cascade do |t|
     t.bigint "tank_id"
     t.integer "animals_added"
@@ -121,7 +127,9 @@ ActiveRecord::Schema.define(version: 2020_05_06_175333) do
     t.datetime "operation_date"
     t.string "action"
     t.bigint "family_id"
+    t.bigint "operation_batch_id"
     t.index ["family_id"], name: "index_operations_on_family_id"
+    t.index ["operation_batch_id"], name: "index_operations_on_operation_batch_id"
     t.index ["tank_id"], name: "index_operations_on_tank_id"
   end
 

--- a/spec/factories/families.rb
+++ b/spec/factories/families.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :family do
-    female { nil }
-    male { nil }
+    female factory: :animal
+    male factory: :animal
   end
 end

--- a/spec/factories/operation_batches.rb
+++ b/spec/factories/operation_batches.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :operation_batch do
+    
+  end
+end

--- a/spec/factories/operations.rb
+++ b/spec/factories/operations.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
   factory :operation do
     tank { nil }
-    animals_added { 1 }
-    animals_added_family_id { 1 }
   end
 end

--- a/spec/features/group_operations_in_operation_batches_spec.rb
+++ b/spec/features/group_operations_in_operation_batches_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe "Group Operations in OperationBatches" do
+  it "allows ordered sets of operations swapping families between two tanks" do
+    # Swapping families between tanks A and B
+
+    tank_a = FactoryBot.create(:tank)
+    family_i = FactoryBot.create(:family, tank: tank_a)
+    tank_b = FactoryBot.create(:tank)
+    family_j = FactoryBot.create(:family, tank: tank_b)
+
+    tank_c = FactoryBot.create(:tank)
+
+    operation_batch = FactoryBot.create(:operation_batch)
+
+    operation_1 = FactoryBot.create(:operation, operation_batch: operation_batch,
+                                                action: :remove_family, tank: tank_a)
+    operation_2 = FactoryBot.create(:operation, operation_batch: operation_batch,
+                                                action: :add_family, tank: tank_c, family: family_i)
+    operation_3 = FactoryBot.create(:operation, operation_batch: operation_batch,
+                                                action: :remove_family, tank: tank_b)
+    operation_4 = FactoryBot.create(:operation, operation_batch: operation_batch,
+                                                action: :add_family, tank: tank_a, family: family_j)
+    operation_5 = FactoryBot.create(:operation, operation_batch: operation_batch,
+                                                action: :remove_family, tank: tank_c)
+    operation_6 = FactoryBot.create(:operation, operation_batch: operation_batch,
+                                                action: :add_family, tank: tank_b, family: family_i)
+
+
+    operation_batch.operations.each(&:perform)
+    [tank_a, tank_b, tank_c].each(&:reload)
+
+    aggregate_failures do
+      expect(operation_batch.operations[0]).to eq operation_1
+      expect(operation_batch.operations[1]).to eq operation_2
+      expect(operation_batch.operations[2]).to eq operation_3
+      expect(operation_batch.operations[3]).to eq operation_4
+      expect(operation_batch.operations[4]).to eq operation_5
+      expect(operation_batch.operations[5]).to eq operation_6
+
+      expect(tank_a.family).to eq(family_j)
+      expect(tank_b.family).to eq(family_i)
+      expect(tank_c).to be_empty
+    end
+  end
+end

--- a/spec/models/operation_batch_spec.rb
+++ b/spec/models/operation_batch_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OperationBatch, type: :model do
+  it { is_expected.to have_many(:operations) }
+end


### PR DESCRIPTION
See: https://www.github.com/rubyforgood/abalone/issues/140

# Checklist:

- [X] I have performed a self-review of my own code,
- [X] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [X] I have added tests that prove my fix is effective or that my feature works,
- [X] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [X] Title include "WIP" if work is in progress.

See #140

### Description
Staff want to be able to group operation(s) in order to understand them at a different level of granularity. (Kind of like how we group related commits into a PR)

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Purely through RSpec, as there is no UI for viewing or managing Operations at this time.