### PR TITLE
Resolve warnings in Test Suite

### DIFF
--- a/spec/models/consolidation_report_spec.rb
+++ b/spec/models/consolidation_report_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ConsolidationReport, type: :model do
   it "ConsolidationReport has associations" do
     is_expected.to belong_to(:family)
-    is_expected.to belong_to(:tank_from), class_name: 'Tank'
-    is_expected.to belong_to(:tank_to), class_name: 'Tank'
+    is_expected.to belong_to(:tank_from).class_name('Tank')
+    is_expected.to belong_to(:tank_to).class_name('Tank')
   end
 end


### PR DESCRIPTION
There were a few warnings occuring when the tests were ran, which were a
bit rough to think through when reviewing for test failures.

I believe they may also have been indicating that the expectations we
thought we had in place were not actually in place.

