### PR TITLE
🚧  WIP: A Very Docker Development Environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,6 @@ COPY Gemfile.lock /myapp/Gemfile.lock
 RUN bundle install
 COPY . /myapp
 
-# Add a script to be executed every time the container starts.
-COPY entrypoint.sh /usr/bin/
-RUN chmod +x /usr/bin/entrypoint.sh
-ENTRYPOINT ["entrypoint.sh"]
 EXPOSE 3000
 
 # Start the main process.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+nuke:
+	docker-compose down --volumes

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
+build:
+	docker-compose build app
+
 nuke:
 	docker-compose down --volumes

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,49 @@
+minty_fresh: nuke schema_migrate dev_env
+
+dev_env:
+	docker-compose up --detach web delayed_job
+	@echo -
+	@echo - Services started! Watch development logs with 'make watch'.
+	@echo -
+
+watch:
+	docker-compose logs --follow web delayed_job
+
+console:
+	docker-compose run --rm console
+
+test: spec lint
+
+spec: schema_migrate
+	@echo -
+	@echo - Running specs!
+	@echo -
+	docker-compose run --rm rspec
+
+lint:
+	@echo -
+	@echo - Running Rubocop!
+	@echo -
+	docker-compose run --rm rubocop
+
+database_started:
+	@echo - Starting up database.
+	docker-compose up --detach db
+
+schema_migrate: database_started
+	@echo -
+	@echo - Applying any pending migrations.
+	@echo -
+	docker-compose run --rm schema_migrate
+
+schema_status:
+	docker-compose run --rm pending_migrations
+
 build:
 	docker-compose build app
 
 nuke:
+	@echo -
+	@echo - Stopping and destroying development services and database.
+	@echo -
 	docker-compose down --volumes

--- a/bin/dbinit/001-create-databases.sql
+++ b/bin/dbinit/001-create-databases.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE abalone_development;
+CREATE DATABASE abalone_test;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     image: abalone
     volumes:
       - .:/myapp
+      - apptmp:/myapp/tmp
     depends_on:
       db:
         condition: service_healthy
@@ -29,3 +30,4 @@ services:
 
 volumes:
   dbdata:
+  apptmp:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
 
   app: &app
     build: .
+    image: abalone
     volumes:
       - .:/myapp
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     <<: *app
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
   delayed_job:
     <<: *app
     command: bundle exec rails jobs:work

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
   app: &app
     build: .
     image: abalone
+    environment:
+      RAILS_ENV: development
     volumes:
       - .:/myapp
       - apptmp:/myapp/tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   db:
     image: postgres
     volumes:
-      - ./tmp/db:/var/lib/postgresql/data
+      - dbdata:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_PORT: 5432
@@ -23,3 +23,6 @@ services:
       - .:/rails-docker
     depends_on:
       - db
+
+volumes:
+  dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,13 @@ services:
     volumes:
       - .:/myapp
       - apptmp:/myapp/tmp
+    tmpfs:
+      - /myapp/tmp/pids
     depends_on:
       db:
         condition: service_healthy
   web:
     <<: *app
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
       - "127.0.0.1:3000:3000"
   delayed_job:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,23 @@ services:
   delayed_job:
     <<: *app
     command: bundle exec rails jobs:work
+  # These are convenience "services" intended to be "run" once and removed
+  # not "docker-compose up"'d for a long running process
+  schema_migrate:
+    <<: *app
+    command: bundle exec rails db:migrate
+  pending_migrations:
+    <<: *app
+    command: bundle exec rails db:migrate:status
+  console:
+    <<: *app
+    command: bundle exec rails console
+  rspec:
+    <<: *app
+    command: bundle exec rspec
+  rubocop:
+    <<: *app
+    command: bundle exec rubocop
 
 volumes:
   dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,25 +9,22 @@ services:
       POSTGRES_PASSWORD: password
     healthcheck:
       test: pg_isready --host=db --user=postgres --dbname=abalone_development
-    
-  web:
+
+  app: &app
     build: .
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/myapp
+    depends_on:
+      db:
+        condition: service_healthy
+  web:
+    <<: *app
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
       - "3000:3000"
-    depends_on:
-      db:
-        condition: service_healthy
   delayed_job:
-    build: .
+    <<: *app
     command: bundle exec rails jobs:work
-    volumes:
-      - .:/rails-docker
-    depends_on:
-      db:
-        condition: service_healthy
 
 volumes:
   dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,15 @@
-version: '3'
+version: '2.4'
 services:
   db:
     image: postgres
     volumes:
       - dbdata:/var/lib/postgresql/data
+      - ./bin/dbinit:/docker-entrypoint-initdb.d
     environment:
       POSTGRES_PASSWORD: password
-      POSTGRES_PORT: 5432
+    healthcheck:
+      test: pg_isready --host=db --user=postgres --dbname=abalone_development
+    
   web:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
@@ -15,14 +18,16 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
   delayed_job:
     build: .
     command: bundle exec rails jobs:work
     volumes:
       - .:/rails-docker
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
 volumes:
   dbdata:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-# Remove a potentially pre-existing server.pid for Rails.
-rm -f /myapp/tmp/pids/server.pid
-
-# Then exec the container's main process (what's set as CMD in the Dockerfile).
-exec "$@"


### PR DESCRIPTION
No current issue.

Experimental.

### Description

In an effort to make getting a development environment up and running easier, this applied judicious automation with Docker, docker-compose, and a Makefile.

TODO:
- [x] speed up database by mounting its data directory to a Docker volume instead of the host
- [x] nip that pesky pid file problem in the bud
- [x] works on Linux?
- [x] works on Windows?

- [ ] default the `db` service to listen on host's localhost:5432?
    - so that a developer could choose to use the container for the database while running all the Ruby on their host computer? Risk: port conflicts on developer computers who already have Postgres for Windows or Postgres.app installed and might not know how or want to do something about it.

- [ ] document the process of using this docker-compose'd environment, either via the make targets or directly with `docker-compose` commands

- [ ] document how to install make on Windows for a more better experience
    - This might be as simple as:

* Install [Chocolatey](https://chocolatey.org/install) (something similar to HomeBrew for Windows)
* Use Chocolatey to install make: `choco install make` in a command window running as Administrator


### Type of change

* This change requires a documentation update (for developers)

### How Has This Been Tested?

On a development computer with Docker Desktop installed:

* run `make minty_fresh` to get a minty fresh development instance
* run `make nuke` then `make test` to see the environment get created from scratch to run the tests
