### PR TITLE
default the db service to listen on host's localhost:5432

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -22,10 +22,10 @@ default: &default
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
-development:
+development: &development
   <<: *default
   database: abalone_development
-  host: db
+  host: <%= ENV['ABALONE_DATABASE_HOSTNAME'] || 'localhost' %>
   username: postgres
   password: password
   pool: 5
@@ -61,7 +61,7 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
+  <<: *development
   database: abalone_test
 
 # As with config/secrets.yml, you never want to store sensitive information,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - ./bin/dbinit:/docker-entrypoint-initdb.d
     environment:
       POSTGRES_PASSWORD: password
+    ports:
+      - "127.0.0.1:5432:5432"
     healthcheck:
       test: pg_isready --host=db --user=postgres --dbname=abalone_development
 
@@ -15,6 +17,7 @@ services:
     image: abalone
     environment:
       RAILS_ENV: development
+      ABALONE_DATABASE_HOSTNAME: db
     volumes:
       - .:/myapp
       - apptmp:/myapp/tmp


### PR DESCRIPTION
### Description

Forward the `db` service's port to the host's loopback interface, so that a developer could choose to use docker-compose only for a container to run the database while running all the Ruby processes on their host computer. `127.0.0.1:5432:5432` was chosen over `5432:5432` so that the PostgreSQL would not be available to all other computers on the host computer's network (say, a coffee shop wifi).

This also updates the development database config to default to using "localhost" for the database host to support a typical dev environment where Ruby processes are running on the host OS. It accepts an environment variable `ABALONE_DATABASE_HOSTNAME` (named in the style of the existing `ABALONE_DATABASE_PASSWORD` variable) to override the database hostname. The compose file has been updated to override with the hostname of the composed "db" service.

The test database config really only differs from the development configuration.

Risk: port conflicts on developer computers who already have Postgres for Windows or Postgres.app installed and might not know how or want to stop or uninstall those services.

### Type of change

* New feature (non-breaking change which adds functionality _to the development environment only_)

### How Has This Been Tested?

On a macOS computer with a Ruby and NodeJS environment already available in the host OS, I started only the `db` docker-compose'd service. Then in the host's development environment, I ran common commands: `rake db:migrate`, `rspec`, and `rails s`.