### PR TITLE
only test on pushes to master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+    - master
 sudo: false
 language: ruby
 before_install: gem install bundler


### PR DESCRIPTION
This does *not* affect testing pull requests.

With both **Build pushed branches** and **Build pushed pull requests** ON at Travis CI, pull requests trigger 2 builds.

![Travis build settings screenshot showing both are ON](https://user-images.githubusercontent.com/517302/89736509-e64bb880-da37-11ea-8839-708a45f92465.png)


This config change filters the branches considered for the **Build pushed branches** to only build when master has a push (e.g. when it is updated by a merge from a pull request). **Build push pull requests** will still trigger builds for branches associated with pull requests.
