### PR TITLE
make dev_env the default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-minty_fresh: nuke schema_migrate dev_env
-
 dev_env:
 	docker-compose up --detach web delayed_job
 	@echo -
 	@echo - Services started! Watch development logs with 'make watch'.
 	@echo -
+
+minty_fresh: nuke schema_migrate dev_env
 
 watch:
 	docker-compose logs --follow web delayed_job


### PR DESCRIPTION
`make` defaults to running the first target. So before this change, if someone types only "`make`" it will scrap their development environment and setup a whole new one. That's probably not a good default.