### PR TITLE
Removed the dev env db username/password

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -26,8 +26,6 @@ development: &development
   <<: *default
   database: abalone_development
   host: <%= ENV['ABALONE_DATABASE_HOSTNAME'] || 'localhost' %>
-  username: postgres
-  password: password
   pool: 5
 
   # The specified database role being used to connect to postgres.


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- [ ] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->



### Description
Having this constraint forces developers to have the username postres, and can 
cause unessesary install issues for those who are less familiar
with pg. I suggest removing this constraint all together for the dev
environment as I generally find it unnecessary to have a username/pasword on
the dev env.

Resolves #265 

Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
Decrease setup difficulty.
  - What alternative solutions did you consider?
Could use env vars for username password on dev env, but I find that it is usually not necessary to enforce dev env passwords for the db.
  - What are the tradeoffs for your solution?
not sure. willing to discuss.   

List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

Install config update


