### PR TITLE
set db credentials for running the app via compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ The web app will be available on your host at `http://localhost:3000`. The logs 
 * `make database_seeds` will seed the database according to `seeds.rb`.
 * `make nuke` will stop all Abalone docker services, remove containers, and delete the development and test databases. This is also used in the `make minty_fresh` command to restart the development and test environment with a clean slate.
 
+### Only the Database
+
+Some developers prefer to run the Ruby and Rails processes directly on their host computers instead of running everything in contianers.
+It might still be convenient for those developers to run the database in a container and not deal with the installation of yet another server on their computer.
+To do so:
+
+* set an environment variable on your host: `export DATABASE_URL="postgres://dockerpg:supersecret@localhost:54321"`
+* start the database with `make database_started`
+
 ## Contribute
 We would love to have you contribute! Checkout the Issues tab and make sure you understand the acceptance criteria before starting one. Before you start, get familiar with important terms, how the app works right now, sample data and the steps to MVP below:
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -63,6 +63,15 @@ development: &development
 test:
   <<: *development
   database: abalone_test
+  # You wouldn't think you need to do this, but adding
+  # the url: key if there is a URL set in the environment
+  # ensures that the URL is used to merge the test DB config
+  # when rake db:* tasks try to manipulate both development
+  # and test databases. The db name given above will still
+  # override the db name given in the URL. Trying to manipulate
+  # both dev and test databases when there is a URL was turned
+  # off in rails/rails#37351, but that hasn't been released yet.
+  <%= "url: #{ENV['DATABASE_URL']}" if ENV['DATABASE_URL'] %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/database.yml
+++ b/config/database.yml
@@ -27,8 +27,6 @@ development: &development
   database: abalone_development
   host: <%= ENV['ABALONE_DATABASE_HOSTNAME'] || 'localhost' %>
   pool: 5
-  username: postgres
-  password: password
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,12 @@ services:
       - dbdata:/var/lib/postgresql/data
       - ./bin/dbinit:/docker-entrypoint-initdb.d
     environment:
-      POSTGRES_PASSWORD: password
+      POSTGRES_USER: dockerpg
+      POSTGRES_PASSWORD: supersecret
     ports:
       - "127.0.0.1:5432:5432"
     healthcheck:
-      test: pg_isready --host=db --user=postgres --dbname=abalone_development
+      test: pg_isready --host=db --user=dockerpg --dbname=abalone_development
 
   app: &app
     build: .
@@ -18,6 +19,7 @@ services:
     environment:
       RAILS_ENV: development
       ABALONE_DATABASE_HOSTNAME: db
+      DATABASE_URL: postgres://dockerpg:supersecret@db
     volumes:
       - .:/myapp
       - apptmp:/myapp/tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: dockerpg
       POSTGRES_PASSWORD: supersecret
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:54321:5432"
     healthcheck:
       test: pg_isready --host=db --user=dockerpg --dbname=abalone_development
 


### PR DESCRIPTION
### Description

This ought to ensure that the make targets work by using a consistent set of database credentials in the docker-composed environment.

* `DATABASE_URL` provides all the app-derivative services with the connection information for the postgres server running in Docker.

* `POSTGRES_USER` is set to "dockerpg" for the database server. This overrides [the postgres image's default "postgres" user](https://github.com/docker-library/docs/blob/master/postgres/README.md#postgres_user). My hope here is to increase the usefulness of error messages about connecting to the database because they will complain about a "dockerpg" user which will be distinct from the usual "postgres" user that exists in standard PostgreSQL installs on the host.

The [database username and password were removed from `config/database.yml`](https://github.com/rubyforgood/abalone/pull/264) to support development environments where PostgreSQL has been configured to trust the developer's OS user and not require a password. This is common when using PostgreSQL installed via Homebrew or Postgres.app and when running the Ruby processes (rails server/console, rspec, etc) directly on the host OS. If a developer wanted to run Rails processes directly on their host while also taking advantage of the PostgreSQL server running in Docker, they can set the `DATABASE_URL` environment variable in their host shell to `postgres://dockerpg:supersecret@localhost` to tell Rails where to find the database without modifying `config/database.yml`.

### Type of change

* Bug fix - for dev environment (non-breaking change which fixes an issue)
