### PR TITLE
[321] Can delete tanks

### DIFF
--- a/app/controllers/tanks_controller.rb
+++ b/app/controllers/tanks_controller.rb
@@ -1,11 +1,21 @@
 class TanksController < ApplicationController
-  before_action :set_tank, only: [:show]
+  before_action :set_tank, only: [:show, :destroy]
 
   def index
     @tanks = Tank.all
   end
 
   def show; end
+
+  # DELETE /families/1
+  # DELETE /families/1.json
+  def destroy
+    @tank.destroy
+    respond_to do |format|
+      format.html { redirect_to tanks_url, notice: 'Tank was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
 
   private
 

--- a/app/controllers/tanks_controller.rb
+++ b/app/controllers/tanks_controller.rb
@@ -7,8 +7,8 @@ class TanksController < ApplicationController
 
   def show; end
 
-  # DELETE /families/1
-  # DELETE /families/1.json
+  # DELETE /tanks/1
+  # DELETE /tanks/1.json
   def destroy
     @tank.destroy
     respond_to do |format|

--- a/app/models/measurement_event.rb
+++ b/app/models/measurement_event.rb
@@ -1,4 +1,4 @@
 class MeasurementEvent < ApplicationRecord
   belongs_to :tank, optional: true
-  has_many :measurements
+  has_many :measurements, dependent: :destroy
 end

--- a/app/models/tank.rb
+++ b/app/models/tank.rb
@@ -9,7 +9,7 @@ class Tank < ApplicationRecord
   has_one :family, required: false
 
   delegate :name, to: :facility, prefix: true
-  
+
   def empty?
     family.blank?
   end

--- a/app/models/tank.rb
+++ b/app/models/tank.rb
@@ -1,7 +1,8 @@
 class Tank < ApplicationRecord
   belongs_to :facility, optional: true
+  has_many :operations, dependent: :destroy
   has_many :post_settlement_inventories
-  has_many :measurement_events
+  has_many :measurement_events, dependent: :destroy
   # has_many :measurements, through: :measurement_events
   has_many :measurements
 

--- a/app/views/tanks/index.html.erb
+++ b/app/views/tanks/index.html.erb
@@ -25,7 +25,7 @@
             <td><%= tank.facility_name %></td>
             <td><%= link_to 'Show', tank %></td>
             <td><%= link_to image_tag("icons/edit.svg", size: 24), "#" %></td>
-            <td><%= link_to image_tag("icons/trash.svg", size: 24), "#" %></td>
+            <td><%= link_to image_tag("icons/trash.svg", size: 24), tank, method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/tanks/index.html.erb
+++ b/app/views/tanks/index.html.erb
@@ -1,7 +1,5 @@
 <section class="section facilities__index">
   <div class="container facilities__index__container">
-    <p id="notice"><%= notice %></p>
-
     <div class="facilities__index__container__header">
       <h1 class="title">Tanks</h1>
       <%= link_to "#", class: "button-primary" do %>

--- a/spec/features/tanks/destroy_spec.rb
+++ b/spec/features/tanks/destroy_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe "When I visit the tank Index page" do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  it "Then I click the delete button, tank should be deleted" do
+    tank1 = create(:tank)
+    tank_count = Tank.count
+
+    visit tanks_path
+
+    link = find("a[data-method='delete'][href='#{tank_path(tank1.id)}']")
+
+    within('tbody') do
+      expect(page).to have_xpath('.//tr', count: tank_count)
+      link.click
+      expect(page).to have_xpath('.//tr', count: (tank_count - 1))
+    end
+  end
+end

--- a/spec/features/tanks/index_spec.rb
+++ b/spec/features/tanks/index_spec.rb
@@ -12,9 +12,9 @@ describe "When I visit the tank index page" do
 
     visit tanks_path
 
-    tanks.each do |tank|  
+    tanks.each do |tank|
       expect(page).to have_content(tank.name)
-      expect(page).to have_content(tank.facility_name)  
+      expect(page).to have_content(tank.facility_name)
     end
   end
 end


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #321

### Description
This ticket sets up the destroy action to delete tanks
   
### Type of change
New feature

### How Has This Been Tested?
Login in to the app. Go to tanks index view. Click the trash can to delete a tank. 

### Screenshots
<img width="1516" alt="Screen Shot 2020-09-21 at 3 20 22 PM" src="https://user-images.githubusercontent.com/3247447/93817064-02896a80-fc1e-11ea-8d52-55be131d5fbe.png">

