### PR TITLE
[319] Set up TanksController #edit and #update actions

### DIFF
--- a/app/controllers/tanks_controller.rb
+++ b/app/controllers/tanks_controller.rb
@@ -1,5 +1,5 @@
 class TanksController < ApplicationController
-  before_action :set_tank, only: [:show, :destroy]
+  before_action :set_tank, only: [:show, :edit, :update, :destroy]
 
   def index
     @tanks = Tank.all
@@ -17,6 +17,16 @@ class TanksController < ApplicationController
       redirect_to tank_path(@tank), notice: 'Tank was successfully created.'
     else
       render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @tank.update(tank_params)
+      redirect_to tank_path(@tank), notice: 'Tank was successfully updated.'
+    else
+      render :edit
     end
   end
 

--- a/app/views/tanks/edit.html.erb
+++ b/app/views/tanks/edit.html.erb
@@ -1,0 +1,9 @@
+<section class="section facilities__form">
+  <div class="container facilities__form__container">
+    <h1 class="title">Edit Tank</h1>
+    <div class="facilities__form__container__body">
+      <%= render 'form', tank: @tank %>
+    </div>
+    <%= link_to '<< Back', tanks_path, class: "button-outline-primary" %>
+  </div>
+</section>

--- a/app/views/tanks/index.html.erb
+++ b/app/views/tanks/index.html.erb
@@ -22,7 +22,7 @@
             <td><%= tank.name %></td>
             <td><%= tank.facility_name %></td>
             <td><%= link_to 'Show', tank %></td>
-            <td><%= link_to image_tag("icons/edit.svg", size: 24), "#" %></td>
+            <td><%= link_to image_tag("icons/edit.svg", size: 24), edit_tank_path(tank) %></td>
             <td><%= link_to image_tag("icons/trash.svg", size: 24), tank, method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>

--- a/app/views/tanks/show.html.erb
+++ b/app/views/tanks/show.html.erb
@@ -5,14 +5,17 @@
     </div>
     <div class="facilities__show__container__body mb-5">
       <p>
-        <strong>Name:</strong>
-        <%= @tank.name %>
-      </p>
-
-      <p>
         <strong>Facility:</strong>
         <%= @tank.facility_name %>
       </p>
+
+      <p>
+        <strong>Name:</strong>
+        <%= @tank.name %>
+      </p>
     </div>
+
+    <%= link_to '<< BACK', tanks_path, class: "mr-3 mb-3 button-outline-primary" %>
+    <%= link_to "Edit", edit_tank_path(@tank), class: "button-outline-primary mt-4" %>
   </div>
 </section>

--- a/spec/features/tanks/update_spec.rb
+++ b/spec/features/tanks/update_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe "When I visit the tank Edit page" do
+  let(:user) { create(:user) }
+  let!(:facility) { create(:facility, organization_id: user.organization_id) }
+
+  before do
+    sign_in user
+  end
+
+  it "And fill out the form and click the submit button, tank should be updated" do
+    tank = create(:tank)
+
+    visit edit_tank_path(tank)
+
+    within('form') do
+      select(facility.name, from: 'Facility')
+      fill_in 'tank_name', with: "Gary's old tank"
+      click_on 'Submit'
+    end
+
+    expect(page).to have_content 'Tank was successfully updated.'
+    expect(page).to have_content(facility.name)
+    expect(page).to have_content "Gary's old tank"
+  end
+end


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #319

### Description
Give the ability for an admin user to edit and update a Tank record from the Tanks index page

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Include feature test to make sure an existing Tank record can have it's Facility association and Name updated, and the updated record displays properly on the Tank show page.

### Screenshots
<img width="1440" alt="Screen Shot 2020-09-22 at 9 10 09 AM" src="https://user-images.githubusercontent.com/38434137/93908482-8477a300-fcb3-11ea-8417-1cc5dd7fee23.png">

