### PR TITLE
[342] Set up UsersController#show

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,6 @@
 class UsersController < ApplicationController
   before_action :admin?, only: [:index, :show, :new, :create, :edit, :update, :destroy]
   before_action :set_user, only: [:show]
-  before_action :redirect_non_admin_users, only: [:show]
 
   def index; end
 
@@ -20,14 +19,10 @@ class UsersController < ApplicationController
   private
 
   def admin?
-    current_user.admin?
+    redirect_to root_path unless current_user.admin?
   end
 
   def set_user
     @user = User.find(params[:id])
-  end
-
-  def redirect_non_admin_users
-    redirect_to root_path unless current_user.admin?
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,7 @@
-class UsersController < ApplicationControler
+class UsersController < ApplicationController
   before_action :admin?, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+  before_action :set_user, only: [:show]
+  before_action :redirect_non_admin_users, only: [:show]
 
   def index; end
 
@@ -19,5 +21,13 @@ class UsersController < ApplicationControler
 
   def admin?
     current_user.admin?
+  end
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def redirect_non_admin_users
+    redirect_to root_path unless current_user.admin?
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,18 @@
+<section class="section facilities__show">
+  <div class="container facilities__show__container">
+    <div class="facilities__show__container__header">
+      <h1 class="title">User</h1>
+    </div>
+    <div class="facilities__show__container__body mb-5">
+      <p>
+        <strong>Organization:</strong>
+        <%= @user.organization.name %>
+      </p>
+
+      <p>
+        <strong>Email:</strong>
+        <%= @user.email %>
+      </p>
+    </div>
+  </div>
+</section>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe UsersController do
+  include Devise::Test::ControllerHelpers
+
+  describe '#show' do
+    it 'should have response code 200 for admin user' do
+      user = create(:user, role: "admin")
+      sign_in user
+      get :show, params: { id: user.id }
+
+      expect(response.code).to eq '200'
+    end
+
+    it 'should have response code 302 for non-admin user' do
+      user = create(:user, role: "user")
+      sign_in user
+      get :show, params: { id: user.id }
+
+      expect(response.code).to eq '302'
+    end
+  end
+end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe "When I visit the user Show page" do
+  it "as an admin, I see information of a specific user" do
+    user = create(:user, role: "admin")
+    sign_in user
+
+    visit user_path(user)
+
+    expect(page).to have_content(user.email)
+    expect(page).to have_content(user.organization.name)
+  end
+
+  it "as a user, I see information of a specific user" do
+    user = create(:user, role: "user")
+    sign_in user
+
+    visit user_path(user)
+
+    expect(page).not_to have_content(user.email)
+    expect(page).not_to have_content(user.organization.name)
+  end
+end


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #342

### Description
* Allow admin users to view user show page, which displays the user's email and organization name. Non-admin users will be redirected back to the application home page.
* Includes a bug fix in the `UsersController` where it was inheriting from `ApplicationControler` instead of `ApplicationController`

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
* Feature test to ensure that an admin user can properly view a user's show page, and a non-admin user cannot gain access to the show view.
* Controller test that expects a 200 response for admin users and a 302 redirection for non-admins

### Screenshots
<img width="1440" alt="Screen Shot 2020-09-22 at 11 38 59 AM" src="https://user-images.githubusercontent.com/38434137/93923439-3e790a00-fcc8-11ea-9164-f4ee41b5f669.png">

