### PR TITLE
[#436] Add Facility model validation

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -19,6 +19,9 @@ class Facility < ApplicationRecord
 
   has_many :locations
 
+  validates :name, presence: true
+  validates :code, presence: true, uniqueness: { scope: :organization_id }
+
   after_commit { Rails.cache.delete('facility_codes') }
 
   # ReportsKit uses this for default labeling

--- a/spec/factories/facility.rb
+++ b/spec/factories/facility.rb
@@ -2,7 +2,9 @@ FactoryBot.define do
   factory :facility do
     val = Faker::Name.unique.name
     name { val }
-    code { val.gsub(/[aeiou|AEIOU|\s]+/, '').strip }
+    sequence :code do |idx|
+      "#{val.gsub(/[aeiou|AEIOU|\s]+/, '').strip}-#{idx}"
+    end
     organization_id { FactoryBot.create(:organization).id }
   end
 end

--- a/spec/models/concerns/validations.rb
+++ b/spec/models/concerns/validations.rb
@@ -85,3 +85,7 @@ shared_examples_for 'organization presence validation' do
     end
   end
 end
+
+shared_examples_for OrganizationScope do
+  it { is_expected.to validate_presence_of :organization }
+end

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -27,9 +27,20 @@ RSpec.describe Facility, type: :model do
     it { is_expected.to have_db_column :organization_id }
 
     describe 'it only has 6 columns' do
-      it { expect(Facility.columns.count).to eq 6 }
+      it { expect(described_class.columns.count).to eq 6 }
     end
   end
 
-  include_examples 'organization presence validation'
+  describe 'validation' do
+    it 'validates presence of' do
+      is_expected.to validate_presence_of :name
+      is_expected.to validate_presence_of :code
+    end
+
+    it 'validate uniqueness of' do
+      is_expected.to validate_uniqueness_of(:code).scoped_to(:organization_id)
+    end
+  end
+
+  it_behaves_like OrganizationScope
 end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- [ ] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->

Resolves #436  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Add model level validation to `Facility` which do
- validates the presence of the name
- validates the presence of code
- validates the uniqueness of code, scoped to organization_id
### Type of change

<!-- Please delete options that are not relevant. -->
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->

Tested with rspec matcher but with some issue regarding shoulda-matchers issue here https://github.com/thoughtbot/shoulda-matchers/issues/814

Instead of using `organization` object, it is scoped to `organization_id`