### PR TITLE
[#437] Add Cohort model validation

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -11,7 +11,9 @@ class Cohort < ApplicationRecord
   has_many :measurements, as: :subject
   has_many :animals
 
-  belongs_to :enclosure, required: false
+  belongs_to :enclosure, required: true
+
+  validates :name, presence: true, uniqueness: { scope: :organization_id }
 
   delegate :name, to: :enclosure, prefix: true, allow_nil: true
 

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :cohort do
     female factory: :female
     male factory: :male
+    enclosure
     organization
     name { Faker::Name.unique.name }
   end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -5,7 +5,18 @@ RSpec.describe Cohort, type: :model do
     is_expected.to belong_to(:male).class_name("Animal").optional
     is_expected.to belong_to(:female).class_name("Animal").optional
     is_expected.to belong_to(:organization)
+    is_expected.to belong_to(:enclosure).required
     is_expected.to have_many(:measurements)
     is_expected.to have_many(:animals)
+  end
+
+  describe 'validation' do
+    it 'validates presence of' do
+      is_expected.to validate_presence_of :name
+    end
+
+    it 'validates uniqueness of' do
+      is_expected.to validate_uniqueness_of(:name).scoped_to(:organization_id)
+    end
   end
 end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- [ ] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->

Resolves #437  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Add model level validation to `Cohort` which do

- validates the presence of the name
- validates the presence of enclosure
- validates the uniqueness of name, scoped to organization_id


### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not 
work as expected)
* This change requires a documentation update
* Documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->

Tested with rspec matcher but with some issue regarding shoulda-matchers issue here thoughtbot/shoulda-matchers#814

Instead of using organization object, it is scoped to organization_id
