### PR TITLE
Add Organization presence validation to OrganizationScope and add spec coverage to relevant models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 
 .DS_Store
 .vscode
+.generators
 
 /public/packs
 /public/packs-test

--- a/app/models/concerns/organization_scope.rb
+++ b/app/models/concerns/organization_scope.rb
@@ -3,6 +3,7 @@ module OrganizationScope
 
   included do
     belongs_to :organization
+    validates :organization, presence: true
 
     scope :for_organization, ->(organization) { where(organization: organization) }
   end

--- a/spec/factories/measurement_events.rb
+++ b/spec/factories/measurement_events.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :measurement_event do
     name { "MyString" }
-    enclosure
-    organizations
+    organization
   end
 end

--- a/spec/models/animal_spec.rb
+++ b/spec/models/animal_spec.rb
@@ -8,4 +8,6 @@ RSpec.describe Animal, type: :model do
     is_expected.to have_many(:animals_shl_numbers).dependent(:destroy)
     is_expected.to have_many(:shl_numbers).through(:animals_shl_numbers)
   end
+
+  include_examples 'organization presence validation'
 end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -8,4 +8,6 @@ RSpec.describe Cohort, type: :model do
     is_expected.to have_many(:measurements)
     is_expected.to have_many(:animals)
   end
+
+  include_examples 'organization presence validation'
 end

--- a/spec/models/concerns/validations.rb
+++ b/spec/models/concerns/validations.rb
@@ -63,3 +63,25 @@ shared_examples_for 'validate values for field' do |field_name|
     end
   end
 end
+
+shared_examples_for 'organization presence validation' do
+  let(:model) { described_class.new organization: organization }
+
+  context 'with organization' do
+    context 'when organization is nil' do
+      let(:organization) { nil }
+
+      it 'is invalid' do
+        expect(model).not_to be_valid
+      end
+    end
+
+    context 'when organization is present' do
+      let(:organization) { create(:organization) }
+
+      it 'is valid' do
+        expect(model).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/enclosure_spec.rb
+++ b/spec/models/enclosure_spec.rb
@@ -6,4 +6,6 @@ RSpec.describe Enclosure, type: :model do
     is_expected.to belong_to(:organization)
     is_expected.to have_many(:measurements)
   end
+
+  include_examples 'organization presence validation'
 end

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -30,4 +30,6 @@ RSpec.describe Facility, type: :model do
       it { expect(Facility.columns.count).to eq 6 }
     end
   end
+
+  include_examples 'organization presence validation'
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -13,4 +13,8 @@ RSpec.describe Location, type: :model do
       expect(location.name_with_facility).to eq "#{location.facility_name} - #{location.name}"
     end
   end
+
+  include_examples 'organization presence validation' do
+    let(:model) { described_class.new name: 'Name of location', facility: create(:facility), organization: organization }
+  end
 end

--- a/spec/models/measurement_event_spec.rb
+++ b/spec/models/measurement_event_spec.rb
@@ -5,4 +5,6 @@ RSpec.describe MeasurementEvent, type: :model do
     is_expected.to have_many(:measurements)
     is_expected.to belong_to(:organization)
   end
+
+  include_examples 'organization presence validation'
 end

--- a/spec/models/measurement_spec.rb
+++ b/spec/models/measurement_spec.rb
@@ -8,4 +8,14 @@ RSpec.describe Measurement, type: :model do
     is_expected.to belong_to(:measurement_type)
     is_expected.to belong_to(:organization)
   end
+
+  include_examples 'organization presence validation' do
+    let(:model) do
+      described_class.new(measurement_event: create(:measurement_event),
+                          measurement_type: create(:measurement_type),
+                          subject: create(:animal),
+                          value: '200',
+                          organization: organization)
+    end
+  end
 end

--- a/spec/models/measurement_type_spec.rb
+++ b/spec/models/measurement_type_spec.rb
@@ -5,4 +5,8 @@ RSpec.describe MeasurementType, type: :model do
     is_expected.to belong_to(:organization)
     is_expected.to have_many(:measurements)
   end
+
+  include_examples 'organization presence validation' do
+    let(:model) { described_class.new name: 'Type', unit: '$', organization: organization }
+  end
 end

--- a/spec/models/operation_spec.rb
+++ b/spec/models/operation_spec.rb
@@ -65,4 +65,8 @@ RSpec.describe Operation, type: :model do
       it { is_expected.to raise_error(Operation::InvalidActionError) }
     end
   end
+
+  include_examples 'organization presence validation' do
+    let(:model) { described_class.new enclosure: create(:enclosure), organization: organization }
+  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Organization, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
   it "Organization has associations" do
     is_expected.to have_many(:users)
     is_expected.to have_many(:facilities)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,4 +10,8 @@ RSpec.describe User, type: :model do
     expect(user.role).to eq 'user'
     expect(user.role).to_not eq 'admin'
   end
+
+  include_examples 'organization presence validation' do
+    let(:model) { described_class.new email: 'test@gmail.com', password: 'secret-token', organization: organization }
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/abalone/issues/438 

**Description**
1. Add Organization presence validation to OrganizationScope and add spec coverage to relevant models
In the process of writing specs, fixed the broken measurement_events factory which had incorrect associations
2. Added `.generators` to `.gitignore` as RubyMine automatically creates it

**Type of change**
Spec coverage of organization validation

**How Has This Been Tested?**
Tested with RSpec