### PR TITLE
Fix the Devise bypass option deprecation warning

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -6,7 +6,7 @@ class PasswordsController < ApplicationController
 
   def update
     if @user.update(user_params)
-      sign_in(@user, bypass: true)
+      bypass_sign_in(@user)
       redirect_to edit_password_url, notice: 'Password was successfully updated.'
     else
       render :edit


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- [ ] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->

Resolves #427 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Devise has deprecated the `:bypass` option for the `sign_in` method. It will be removed in future versions.
We should use the `bypass_sign_in` method instead.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->

* Specs are passing
* I am able to change a user's password locally

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight 
edited element.-->

Deprecation warning before the change:
![cedric_darne_ClapTrap____Code_ruby_abalone](https://user-images.githubusercontent.com/233336/94855584-c06ddf00-03fc-11eb-9fc2-99cd19afccdd.png)

No more Devise deprecation warning after the change:
![cedric_darne_ClapTrap____Code_ruby_abalone](https://user-images.githubusercontent.com/233336/94855606-c8c61a00-03fc-11eb-9bdf-cece0842f921.png)

Password update is still working:
<img width="1573" alt="Abalone_Analytics" src="https://user-images.githubusercontent.com/233336/94855683-ded3da80-03fc-11eb-865e-3d963f3a84bc.png">

