### PR TITLE
Unpin faker gem from master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 4.0', '>= 4.0.1'
   gem "factory_bot_rails"
   gem 'rubocop-rails'
-  gem 'faker', git: 'https://github.com/stympy/faker.git', branch: 'master'
+  gem 'faker'
   gem 'shoulda-matchers'
   gem 'capybara'
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/stympy/faker.git
-  revision: be0e82259445f0ca3ae87cd6fce6e7635a2fc6b1
-  branch: master
-  specs:
-    faker (2.14.0)
-      i18n (>= 1.6, < 2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -141,6 +133,8 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
+    faker (2.14.0)
+      i18n (>= 1.6, < 2)
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -353,7 +347,7 @@ DEPENDENCIES
   delayed_job_active_record
   devise (~> 4.7)
   factory_bot_rails
-  faker!
+  faker
   iostreams
   jbuilder (~> 2.10)
   jquery-rails


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- [ ] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->


### Description
Un-pins faker from master branch. This was leading dependabot to open a PR every time Faker gem's master was updated. We can probably just use the latest release tag.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Specs still good, we weren't using anything not cut into a gem version.
