### PR TITLE
Add stylesheet pack tag for bringing in tailwindcss styles.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bulma-calendar@6.0.7/dist/js/bulma-calendar.min.js"></script>
 
     <%= stylesheet_link_tag    'application', media: 'all' %>
+    <%= stylesheet_pack_tag 'application' %>
   </head>
 
   <body>


### PR DESCRIPTION
We are importing the following TailwindCSS styles through webpacker, so I think we need to add `<%= stylesheet_pack_tag 'application' %>` for them to work in production.

```
tailwindcss/base
tailwindcss/components
tailwindcss/utilities
```