### PR TITLE
Add concept of mortality rate to animals and cohort

### DIFF
--- a/app/models/animal.rb
+++ b/app/models/animal.rb
@@ -13,6 +13,7 @@ class Animal < ApplicationRecord
   has_many :measurements, as: :subject
   has_many :animals_shl_numbers, dependent: :destroy
   has_many :shl_numbers, through: :animals_shl_numbers
+  has_one :mortality_event
 
   validates :tag, uniqueness: { scope: %i[cohort_id] }
 
@@ -32,5 +33,13 @@ class Animal < ApplicationRecord
 
   def shl_number_codes(join = ",")
     shl_numbers.pluck(:code).join(join)
+  end
+
+  def alive?
+    !dead?
+  end
+
+  def dead?
+    mortality_event.present?
   end
 end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -9,7 +9,7 @@ class Cohort < ApplicationRecord
 
   has_many :animals
   has_many :measurements, as: :subject
-  has_many :animals
+  has_many :mortality_events
 
   belongs_to :enclosure, required: false
 
@@ -24,6 +24,10 @@ class Cohort < ApplicationRecord
 
   def to_s
     name.blank? ? "Cohort #{id}" : name
+  end
+
+  def mortality_count
+    mortality_events.count
   end
 
   # def name

--- a/app/models/mortality_event.rb
+++ b/app/models/mortality_event.rb
@@ -1,0 +1,4 @@
+class MortalityEvent < ApplicationRecord
+  belongs_to :animal
+  belongs_to :cohort
+end

--- a/db/migrate/20201020103647_create_mortality_events_table.rb
+++ b/db/migrate/20201020103647_create_mortality_events_table.rb
@@ -1,0 +1,12 @@
+class CreateMortalityEventsTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :mortality_events do |t|
+      t.datetime :mortality_date
+      t.references :animal
+      t.references :cohort
+      t.integer :mortality_count
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_210137) do
+ActiveRecord::Schema.define(version: 2020_10_20_103647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,6 +167,17 @@ ActiveRecord::Schema.define(version: 2020_09_24_210137) do
     t.index ["organization_id"], name: "index_measurements_on_organization_id"
     t.index ["processed_file_id"], name: "index_measurements_on_processed_file_id"
     t.index ["subject_type", "subject_id"], name: "index_measurements_on_subject_type_and_subject_id"
+  end
+
+  create_table "mortality_events", force: :cascade do |t|
+    t.datetime "mortality_date"
+    t.bigint "animal_id"
+    t.bigint "cohort_id"
+    t.integer "mortality_count"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["animal_id"], name: "index_mortality_events_on_animal_id"
+    t.index ["cohort_id"], name: "index_mortality_events_on_cohort_id"
   end
 
   create_table "operation_batches", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -66,6 +66,7 @@ organization_entities[:organizations].each do |org_ent|
   MeasurementType.find_or_create_by(name: 'weight', unit: 'g', organization: org)
   MeasurementType.find_or_create_by(name: 'gonad score', unit: 'number', organization: org)
 
+
   # Create facilities and their associated locations and enclosures
   org_ent[:facilities].each do |fac_ent|
     facility = Facility.find_or_create_by(name: fac_ent[:name], code: fac_ent[:code], organization: org)
@@ -74,6 +75,18 @@ organization_entities[:organizations].each do |org_ent|
 
     # Create animals and a cohort per facility
     cohort = Cohort.find_or_create_by(name: "#{enclosure.name} cohort", enclosure: enclosure, organization: org)
+
+    dead_animal = Animal.find_or_create_by(
+      sex: :female,
+      collection_year: Time.zone.now.year,
+      date_time_collected: Time.zone.now,
+      collection_position: 'Position',
+      cohort: cohort,
+      tag: "D-#{fac_ent[:code]}",
+      organization: org
+    )
+
+    dead_animal.mortality_event.create(cohort: cohort)
 
     male = Animal.find_or_create_by(
       sex: :male,

--- a/spec/factories/mortality_events.rb
+++ b/spec/factories/mortality_events.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :mortality_event do
+    cohort
+    animal
+  end
+end

--- a/spec/models/animal_spec.rb
+++ b/spec/models/animal_spec.rb
@@ -7,7 +7,20 @@ RSpec.describe Animal, type: :model do
     is_expected.to belong_to(:cohort).optional
     is_expected.to have_many(:animals_shl_numbers).dependent(:destroy)
     is_expected.to have_many(:shl_numbers).through(:animals_shl_numbers)
+    is_expected.to have_one(:mortality_event)
   end
 
   include_examples 'organization presence validation'
+
+  let!(:animal) { create(:animal) }
+
+  it "should be dead" do
+    create(:mortality_event, animal: animal, cohort: create(:cohort))
+
+    expect(animal.dead?).to eq true
+  end
+
+  it "should be alive" do
+    expect(animal.alive?).to eq true
+  end
 end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Cohort, type: :model do
   it "should have correct amount of mortality_events" do
     animal1 = create(:animal, cohort: cohort)
     animal2 = create(:animal, cohort: cohort)
-    animal3 = create(:animal, cohort: cohort)
+    create(:animal, cohort: cohort)
 
     create(:mortality_event, animal: animal1, cohort: cohort)
     create(:mortality_event, animal: animal2, cohort: cohort)

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -7,7 +7,21 @@ RSpec.describe Cohort, type: :model do
     is_expected.to belong_to(:organization)
     is_expected.to have_many(:measurements)
     is_expected.to have_many(:animals)
+    is_expected.to have_many(:mortality_events)
   end
 
   include_examples 'organization presence validation'
+
+  let!(:cohort) { create(:cohort) }
+
+  it "should have correct amount of mortality_events" do
+    animal1 = create(:animal, cohort: cohort)
+    animal2 = create(:animal, cohort: cohort)
+    animal3 = create(:animal, cohort: cohort)
+
+    create(:mortality_event, animal: animal1, cohort: cohort)
+    create(:mortality_event, animal: animal2, cohort: cohort)
+
+    expect(cohort.mortality_count).to eq 2
+  end
 end

--- a/spec/models/mortality_event_spec.rb
+++ b/spec/models/mortality_event_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe MortalityEvent, type: :model do
+  it "Mortality Event has associations" do
+    is_expected.to belong_to(:animal)
+    is_expected.to belong_to(:cohort)
+  end
+end


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

-->

Resolves #433 

### Description
As per the issue, I have added a mortality event table which has a cohort and animal. There are methods to check how many mortalites there are in a cohort, and methods returning a boolean from the animal model to check if they are alive or dead. I have added tests for this too.

### Type of change

* New feature (non-breaking change which adds functionality)