### PR TITLE
Fix DB seed task

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -86,7 +86,7 @@ organization_entities[:organizations].each do |org_ent|
       organization: org
     )
 
-    dead_animal.mortality_event.create(cohort: cohort)
+    dead_animal.mortality_event = MortalityEvent.create(cohort: cohort)
 
     male = Animal.find_or_create_by(
       sex: :male,


### PR DESCRIPTION
- [x] have performed a self-review of my own code,
- [x]  I have commented my code, particularly in hard-to-understand areas,
- [x]  I have made corresponding changes to the documentation,
- [x]  I have added tests that prove my fix is effective or that my feature works,
- [x]  New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x]  Title include "WIP" if work is in progress.

### Description
I noticed on following the setup instructions that `rake db:seed` fails with the error `NoMethodError: undefined method `create' for nil:NilClass`. It looks like before it has been persisted, you can't call Animal.mortality_event.create.

I've fixed this by assigning the result of `MortalityEvent.create` to `dead_animal.mortality_event`.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested through dropping the database locally, creating it afresh with `rake db:create` and `rake db:migrate` and running the seed task. Confirmed that this seeds the database correctly.

### Screenshots
(Before)
<img width="836" alt="Screenshot 2020-10-23 at 19 35 26" src="https://user-images.githubusercontent.com/14929975/97041347-54981580-1567-11eb-8db5-f232eb234bcf.png">

(After)
<img width="710" alt="Screenshot 2020-10-23 at 19 41 05" src="https://user-images.githubusercontent.com/14929975/97041662-b9ec0680-1567-11eb-96d9-43ae5b62e806.png">
