### PR TITLE
display current organization when user is logged in

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -6,6 +6,12 @@
 </section>
 
 <% if current_user %>
+  <div class="column"></div>
+  <section class="column">
+    <h1 class="has-text-centered title">
+      Your organization: <%= current_organization.name %>
+    </h1>
+  </section>
   <section class="section has-text-centered">
     <div class="container">
       <div class="columns">

--- a/spec/features/home_page_statistics_spec.rb
+++ b/spec/features/home_page_statistics_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Home Page Statistics' do
   describe 'view home page statistics', type: :feature do
-    let(:organization) { create(:organization) }
+    let(:organization) { create(:organization, name: 'White Abalone') }
     let(:user) { create(:user, organization: organization) }
     let!(:animal) { create(:animal, organization: organization) }
     let!(:facility) { create(:facility, organization: organization) }
@@ -13,9 +13,16 @@ RSpec.describe 'Home Page Statistics' do
       expect(page.all('.card-content')).to be_empty
     end
 
+    it 'When I view the home page as a visitor I see no organisation' do
+      visit root_path
+      expect(page.all('.card-content')).to be_empty
+    end
+
     it 'When I login and view the home page I see my company data' do
       sign_in user
       visit root_path
+
+      expect(page.all('h1')[1].text).to eq('Your organization: White Abalone')
       expect(page.all('.card-content')[0].find('.title').text).to eq('1') # Total No. of Animals
       expect(page.all('.card-content')[1].find('.title').text).to eq('1') # No. of Facilities
       expect(page.all('.card-content')[2].find('.title').text).to eq('1') # No. of Cohorts

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -18,6 +18,15 @@ describe "When I visit the user Show page" do
     visit user_path(user)
 
     expect(page).not_to have_content(user.email)
-    expect(page).not_to have_content(user.organization.name)
+    expect(page).to have_content(user.organization.name)
+  end
+
+  it "as a user who's not logged in, I see no user specific information" do
+    user = create(:user)
+
+    visit user_path(user)
+
+    expect(page).not_to have_content(user.email)
+    expect(page).not_to have_content("Your organization: #{user.organization.name}")
   end
 end


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #470

### Description
Added organization name onto homepage, for logged in users. To keep styling consistent, I tried to stick to existing patterns and use the same classes. Below the hero image, there is now a headline reading "Your organization: [organization name]".

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Current user tests have been updated to reflect changes. Logged in users who are not admins can now see their organization name on the page. Additional tests were added to verify that visitors who are not logged in cannot see this information.

### Screenshots

<img width="1025" alt="Screenshot 2020-10-23 at 22 15 58" src="https://user-images.githubusercontent.com/22390758/97054779-5c62b480-157d-11eb-9bf5-3ea6b8b4254b.png">
