### PR TITLE
Reorganize nav bar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,11 +48,6 @@
             <%= link_to 'Animals', animals_path, class: 'navbar-item'%>
             <%= link_to 'Cohorts', cohorts_path, class: 'navbar-item'%>
             <%= link_to 'Operations', operations_path, class: 'navbar-item'%>
-            <% if current_user.admin? %>
-              <%= link_to 'Measurement Types', measurement_types_path, class: 'navbar-item'%>
-              <%= link_to 'Users', users_path, class: 'navbar-item'%>
-            <% end %>
-
             <div class="navbar-item has-dropdown is-hoverable">
               <a class="navbar-link">
                 Uploads
@@ -64,8 +59,18 @@
                 <%= link_to 'Upload a file', new_file_upload_path, class: 'navbar-item'%>
               </div>
             </div>
+            <% if current_user.admin? %>
+              <div class="navbar-item has-dropdown is-hoverable">
+                <a class="navbar-link">
+                  Admin
+                </a>
+                <div class="navbar-dropdown">
+                  <%= link_to 'Measurement Types', measurement_types_path, class: 'navbar-item'%>
+                  <%= link_to 'Users', users_path, class: 'navbar-item'%>
+                </div>
+              </div>
+            <% end %>
           <% end %>
-
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link">
               More
@@ -80,8 +85,8 @@
 
               <hr class="navbar-divider">
 
-              <a href="https://github.com/rubyforgood/abalone/issues/new" target="_blank" class="navbar-item">
-                Report an issue
+              <a href="https://github.com/rubyforgood/abalone" target="_blank" class="navbar-item">
+                Github
               </a>
             </div>
           </div>
@@ -96,13 +101,6 @@
               <% else %>
                 <%= link_to "Login", new_user_session_path, class: "button is-grey-light button-outline-primary" %>
               <% end %>
-
-              <a href="https://github.com/rubyforgood/abalone" target="_blank" class="button is-grey-light">
-                <span class="icon">
-                  <i class="fab fa-github"></i>
-                </span>
-                <strong>Github</strong>
-              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Resolves #467 

### Description
This branch reorganizes the main navigation bar to place the admin-only items in a drop-down menu item and moves the Github button under the _More_ nav item. 

This fixes the nav bar running off of smaller screen sizes that are still larger than the first break-point when admin nav items are present.

### Type of change

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

- Test suite was run
- Manually testing on 13' laptop screen

### Screenshots
Before:
<img width="1439" alt="Screen Shot 2020-11-21 at 4 25 49 PM" src="https://user-images.githubusercontent.com/7053190/99887899-472d8400-2c16-11eb-93f6-b72b2a5e5910.png">

After:
<img width="1439" alt="Screen Shot 2020-11-21 at 4 25 08 PM" src="https://user-images.githubusercontent.com/7053190/99887905-501e5580-2c16-11eb-8a95-f9e7f2438e73.png">

