### PR TITLE
Blazer rake task modifications

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,10 @@ Rails.application.routes.draw do
   get 'about', action: 'show', controller: 'home'
 
   mount ReportsKit::Engine, at: '/'
-  mount Blazer::Engine, at: "blazer"
+
+  authenticate :user do
+    mount Blazer::Engine, at: "blazer"
+  end
 
   root 'home#index'
 end

--- a/lib/tasks/blazer.rake
+++ b/lib/tasks/blazer.rake
@@ -81,22 +81,28 @@ namespace :blazer do
     org_user = "org#{org.id}"
 
     # This conditional accommodates the current hosting environment which requires the role to be set up separately.
-    unless Rails.env.production?
+    if Rails.env.production?
+      <<~SQL
+        BEGIN;
+        GRANT CONNECT ON DATABASE #{db_connection.current_database} TO #{org_user};
+        GRANT USAGE ON SCHEMA public TO #{org_user};
+        GRANT SELECT ON ALL TABLES IN SCHEMA public TO #{org_user};
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO #{org_user};
+        REVOKE SELECT ON users FROM #{org_user};
+        COMMIT;
+      SQL
+    else
       <<~SQL
         BEGIN;
         CREATE ROLE #{org_user} LOGIN PASSWORD '#{org_db_password(org)}';
+        GRANT CONNECT ON DATABASE #{db_connection.current_database} TO #{org_user};
+        GRANT USAGE ON SCHEMA public TO #{org_user};
+        GRANT SELECT ON ALL TABLES IN SCHEMA public TO #{org_user};
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO #{org_user};
+        REVOKE SELECT ON users FROM #{org_user};
         COMMIT;
       SQL
     end
-
-    <<~SQL
-      BEGIN;
-      GRANT CONNECT ON DATABASE #{db_connection.current_database} TO #{org_user};
-      GRANT USAGE ON SCHEMA public TO #{org_user};
-      GRANT SELECT ON ALL TABLES IN SCHEMA public TO #{org_user};
-      ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO #{org_user};
-      COMMIT;
-    SQL
   end
 
   def drop_organization_user(org)

--- a/spec/features/users/update_spec.rb
+++ b/spec/features/users/update_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 describe "When I visit the user Edit page" do
-  let(:admin) { create(:user, :admin) }
+  let(:organization) { create(:organization) }
+  let(:admin) { create(:user, :admin, organization: organization) }
 
   before do
     sign_in admin
@@ -9,7 +10,7 @@ describe "When I visit the user Edit page" do
 
   context "As an admin user" do
     it "Then I can update a user" do
-      user = create(:user)
+      user = create(:user, organization: organization)
 
       visit edit_user_path(user)
 


### PR DESCRIPTION
This branch makes a couple of modifications to the blazer setup  -

First, it updates the blazer rake task so it only creates or drops the organization roles when not run in production. This is to conform to our current hosting, which requires those roles be set manually prior to running the task.

Second, it wraps the blazer mount in devise's authenticate method to provide a more user friendly error than blazer's standard one if an unauthenticated users tries to access that route. This may not be needed once when update the blazer and report routes.

Once merged, I'll test the updated rake task on abalone-staging and make any necessary tweaks.