### PR TITLE
adds back in the missing csv upload link

### DIFF
--- a/app/views/animals/index.html.erb
+++ b/app/views/animals/index.html.erb
@@ -10,9 +10,10 @@
             <span class="ml-2">New Animal</span>
           </button>
         <% end %>
-        <%#= link_to csv_upload_animals_path, class: "button-primary" do %>
-  <!--        CSV Upload <%#= image_tag  "icons/plus.png", size: 17 %>-->
-        <%# end %>
+        <%= link_to csv_upload_animals_path, class: "bg-primary-dark hover:bg-primary text-white font-bold py-2 px-4 rounded inline-flex items-center mr-4 hover:text-white" do %>
+          <%= image_tag  "icons/plus.png", size: 17 %>
+          <span class="ml-2">Upload CSV</span>
+        <% end %>
         <%= link_to animals_path(format: :csv), id: "export_button" do %>
           <button class="bg-primary-dark hover:bg-primary text-white font-bold py-2 px-4 rounded inline-flex items-center">
             Export to CSV

--- a/spec/features/animals/index_spec.rb
+++ b/spec/features/animals/index_spec.rb
@@ -45,4 +45,10 @@ describe "When I visit the animal Index page" do
 
     animals.each { |animal| expect(page).to have_content(animal.tag) }
   end
+
+  it "should link to csv upload" do
+    visit animals_path
+
+    expect(page).to have_content('Upload CSV')
+  end
 end


### PR DESCRIPTION
Resolves #481  <!--fill issue number-->

### Description
In #419 the page was converted from bootstrap to Tailwind. During that process the link was commented out. I uncommented it and added additional Tailwind classes to make the styling match the buttons next to the link. I believe I have successfully recreated every aspect of the buttons (hover, etc). 

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I wrote a test in `spec/features/animals/index_spec.rb`, however it is not much of a feature test. I was looking for a view spec but didn't see any. Is there a better place to test this functionality? 

Additionally, confirmed in the browser that when clicked you get a page that allows you to upload a csv. 

### Screenshots

![image](https://user-images.githubusercontent.com/560375/103965497-709d6300-5123-11eb-8d3c-f3ffc3632301.png)


