### PR TITLE
Possible path for integrating blazer into the site navigation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group :development do
 end
 
 # Report builder
-gem 'reports_kit'
+gem 'reports_kit' # Replaced by blazer reporting - 1/24/21
 gem 'blazer'
 
 # Excel and CSV support

--- a/app/assets/javascripts/reports.js
+++ b/app/assets/javascripts/reports.js
@@ -1,3 +1,5 @@
+// Replaced by blazer reporting - 1/24/21
+
 var Reports = (function () {
   var chart = null;
   var showChart = async function (element) {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,7 +12,7 @@
 @import "variables";
 @import "mixins";
 @import "pages/**/*";
-@import "reports_kit";
+@import "reports_kit"; // Replaced by blazer reporting - 1/24/21
 * {
   font-family: "Poppins", sans-serif;
 }

--- a/app/assets/stylesheets/reports_kit.scss
+++ b/app/assets/stylesheets/reports_kit.scss
@@ -1,3 +1,5 @@
+// Replaced by blazer reporting - 1/24/21
+
 @import "variables";
 @import "mixins";
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,3 +1,5 @@
-class ReportsController < ApplicationController
-  def index; end
-end
+# class ReportsController < ApplicationController
+#   def index; end
+# end
+#
+# Replaced by blazer reporting - 1/24/21

--- a/app/models/animal.rb
+++ b/app/models/animal.rb
@@ -3,8 +3,9 @@ class Animal < ApplicationRecord
 
   include OrganizationScope
   include CsvExportable
-  include ReportsKit::Model
+  include ReportsKit::Model # Replaced by blazer reporting - 1/24/21
 
+  # Replaced by blazer reporting - 1/24/21
   reports_kit do
     contextual_filter :for_organization, ->(relation, context_params) { relation.for_organization(context_params[:organization_id]) }
   end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -24,6 +24,7 @@ class Facility < ApplicationRecord
 
   after_commit { Rails.cache.delete('facility_codes') }
 
+  # Replaced by blazer reporting - 1/24/21
   # ReportsKit uses this for default labeling
   def to_s
     code

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
       <div id="nav-menu" class="pl-2 navbar-menu">
         <div class="navbar-start">
           <% if current_user %>
-            <%= link_to 'Reports', reports_path, class: 'navbar-item'%>
+            <%= link_to 'Reports', reports.root_path, class: 'navbar-item'%>
             <%= link_to 'Facilities', facilities_path, class: 'navbar-item' %>
             <%= link_to 'Enclosures', enclosures_path, class: 'navbar-item'%>
             <%= link_to 'Animals', animals_path, class: 'navbar-item'%>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,4 +1,6 @@
-  <div class="container">
+<!-- Replaced by blazer reporting - 1/24/21  -->
+
+<div class="container">
     <section class="section">
       <h1 class="title">Reports</h1>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
 
   get '/file_uploads/errors/:id', to: 'file_uploads#show_processing_csv_errors', as: 'show_processing_csv_errors'
 
-  resources :reports, only: [:index]
+  #resources :reports, only: [:index]
 
   resources :operations, only: [:index]
 
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
   mount ReportsKit::Engine, at: '/'
 
   authenticate :user do
-    mount Blazer::Engine, at: "blazer"
+    mount Blazer::Engine, at: "blazer", as: 'reports'
   end
 
   root 'home#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,14 +30,14 @@ Rails.application.routes.draw do
 
   get '/file_uploads/errors/:id', to: 'file_uploads#show_processing_csv_errors', as: 'show_processing_csv_errors'
 
-  #resources :reports, only: [:index]
+  # resources :reports, only: [:index] # Replaced by blazer reporting - 1/24/21
 
   resources :operations, only: [:index]
 
   get 'home', action: 'index', controller: 'home'
   get 'about', action: 'show', controller: 'home'
 
-  mount ReportsKit::Engine, at: '/'
+  # mount ReportsKit::Engine, at: '/' # Replaced by blazer reporting - 1/24/21
 
   authenticate :user do
     mount Blazer::Engine, at: "blazer", as: 'reports'

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -1,18 +1,20 @@
-require 'rails_helper'
+# Replaced by blazer reporting - 1/24/21
 
-describe ReportsController do
-  include Devise::Test::ControllerHelpers
-
-  let(:user) { FactoryBot.create(:user) }
-
-  before do
-    sign_in user
-  end
-
-  describe '#index' do
-    it 'should have response code 200' do
-      get :index
-      expect(response.code).to eq '200'
-    end
-  end
-end
+# require 'rails_helper'
+#
+# describe ReportsController do
+#   include Devise::Test::ControllerHelpers
+#
+#   let(:user) { FactoryBot.create(:user) }
+#
+#   before do
+#     sign_in user
+#   end
+#
+#   describe '#index' do
+#     it 'should have response code 200' do
+#       get :index
+#       expect(response.code).to eq '200'
+#     end
+#   end
+# end

--- a/spec/features/reporting_spec.rb
+++ b/spec/features/reporting_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'When I visit the blazer reporting index page' do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  it 'I see the button to create a new query' do
+    visit reports.root_path
+    expect(page).to have_selector(:link_or_button, 'New Query')
+  end
+end


### PR DESCRIPTION
Currently, blazer is not accessible through the site's navigation. This branch offers a possible approach to that by removing the current reports routing and adding `as: reports` to the blazer routes.

An alternative approach can be seen here: https://github.com/ankane/blazer/issues/50#issuecomment-259071162. This appears to requiring forking the gem, which we have avoided doing so far.

@benreyn or @mdworken, any thoughts or preferences on this?

If the proposed option is acceptable, I can finish cleaning it up and prepare a proper PR.
