### PR TITLE
changes the caption-light css

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,7 +25,7 @@ module.exports = {
         warning: "#f2994a",
         success: "#27ae60",
         "dark-light": "#eee",
-        "caption-light": "#9191A2",
+        "caption-light": "#757586",
         "caption-dark": "#ACACC1",
       },
     },


### PR DESCRIPTION
### Description

Using the ANDI tool, we've identified accessibility issues. One of those issues existed on the admin/users page related to the headings on the table found there. This pull request fixes https://github.com/rubyforgood/abalone/issues/565 & https://github.com/rubyforgood/abalone/issues/561 & https://github.com/rubyforgood/abalone/issues/554 & https://github.com/rubyforgood/abalone/issues/551 & https://github.com/rubyforgood/abalone/issues/547 & https://github.com/rubyforgood/abalone/issues/543 & https://github.com/rubyforgood/abalone/issues/539. 

This change is made on a site wide basis so that is something to be aware of. I clicked around and didn't see any drastic change. I used the default ANDI color recommended to me, which provides just enough contrast to pass whatever standards ANDI is applying. 

### Type of change

* Accessibility enhancement 

### How Has This Been Tested?

1. I went through and found all the related issues I could find. I might have missed one along the way, but confirmed via the browser on each of the above pages that all the above linked issues conform to ANDI's standards.
2. Because this is a site wide change, I also clicked around to see if anything looked horrendous. I didn't notice anything that looked out of place. 

### Screenshots
<img width="1436" alt="Screen Shot 2021-01-14 at 5 41 45 PM" src="https://user-images.githubusercontent.com/560375/104662596-cd070200-5690-11eb-9ac4-2041b120483c.png">

