### PR TITLE
add accessible title to Show link

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -30,7 +30,9 @@
             <td class="px-4 py-2"><%= user.email %></td>
             <td class="px-4 py-2"><%= user.role %></td>
             <td class="px-4 py-2"><%= user.organization.name %></td>
-            <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', user %></td>
+            <td class="text-primary-dark px-4 py-2">
+              <%= link_to 'Show', user, title: "Show details for #{user.email}" %>
+            </td>
             <td class="px-4 py-2"><%= link_to image_tag("icons/edit.svg", size: 24), edit_user_path(user) %></td>
             <% unless user == current_user %>
               <td class="px-4 py-2">

--- a/spec/features/users/index_spec.rb
+++ b/spec/features/users/index_spec.rb
@@ -28,6 +28,7 @@ describe "When I visit the user index page" do
       expect(page).to have_content user.role
       expect(page).to have_content user.organization.name
       expect(page).to have_content 'Actions'
+      expect(page).to have_link('Show', title: "Show details for #{user.email}")
     end
   end
 


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #563 

### Description

'Show' links in Users table triggered ANDI's 'Ambiguous Link' warning. To fix this, I added unique titles to each 'Show' link. 

### Type of change

Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested in the browser using the ANDI accessibility tool.
