### PR TITLE
update styles to replace bulma and improve color contrast

### DIFF
--- a/app/views/file_uploads/new.html.erb
+++ b/app/views/file_uploads/new.html.erb
@@ -23,7 +23,7 @@
 
       <div class="field is-grouped">
         <div class="control">
-          <%= submit_tag('Submit', class: 'button is-primary') %>
+          <%= submit_tag('Submit', class: 'button-primary') %>
         </div>
 
         <div class="control">


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #558 

### Description
The Submit button on the File Upload page had low color contrast. As this button was styles using Bulma and I noticed you're working on replacing it as part of #466, I updated the button styles with the same class we're using on the 'Change Password' page.

### Type of change
Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested in the browser using ANDI. Color contrast is now sufficient.
I didn't add unit tests for this, as I didn't think it was necessary.

### Screenshots
<img width="721" alt="Screenshot 2021-02-24 at 19 45 54" src="https://user-images.githubusercontent.com/22390758/109057551-caf58180-76d9-11eb-9b67-bde029f7c1b2.png">