### PR TITLE
fix label tag for file upload input

### DIFF
--- a/app/views/file_uploads/new.html.erb
+++ b/app/views/file_uploads/new.html.erb
@@ -16,7 +16,7 @@
 
       <div class="field">
         <div>
-          <%= label_tag('input_file', 'Select up to 10 files to upload', class: 'label') %>
+          <%= label_tag('input_files[]', 'Select up to 10 files to upload', class: 'label') %>
           <%= file_field_tag 'input_files[]', multiple: true, required: true %>
         </div>
       </div>


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #557 

### Description
The file upload input had a corresponding label, but the two weren't associated properly. Because of this, the file upload wasn't accessible. I have updated the label's _for_ property to match the input id. There was no need to update existing unit tests for this and I have not added any new ones, as I didn't think it was necessary.

### Type of change
Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested in the browser, using ANDI.
