### PR TITLE
add visually hidden class and label for new measurements

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -96,3 +96,14 @@
   box-shadow: unset;
   border-radius: 2px;
 }
+
+// https://www.a11yproject.com/
+.visually-hidden:not(:focus):not(:active) {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/app/views/measurements/new.html.erb
+++ b/app/views/measurements/new.html.erb
@@ -3,6 +3,7 @@
     <h1 class="title">New Measurements</h1>
     <div class="facilities__form__container__body">
       <div class="field">
+        <%= label_tag(:data_import_type, 'Select measurement', class: 'visually-hidden') %>
         <%= select_tag(:data_import_type, options_for_select([
              ['I am taking measurements of animals', :animal_measurements],
              ['I want to measure length and gonad score', :length_gonad_score]

--- a/spec/features/new_measurements_spec.rb
+++ b/spec/features/new_measurements_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe 'When I visit the New Measurements page', type: :feature do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+    visit new_measurement_path
+  end
+
+  it 'Then I can generate a template for my selected measurements' do
+    expect(page).to have_selector('label.visually-hidden')
+    expect(page).to have_content 'I am taking measurements of animals'
+    expect(page).to have_content 'I want to measure length and gonad score'
+    expect(page).to have_link('Generate Template')
+  end
+end


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #552 

### Description
The select element on the 'New Measurements' page was missing a label. To make it accessible, I have added a visually-hidden class to the application styles and used this to add a label that's only visible for screen readers. This class can now be used for any inputs and elements we want to hide in the app.

### Type of change
Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
In the browser, using ANDI.
