### PR TITLE
add screen reader-only page title, update cards and page logo

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,7 +26,7 @@
   -webkit-box-shadow: -4px -1px 33px -5px rgba(0, 0, 0, 0.25);
   -moz-box-shadow: -4px -1px 33px -5px rgba(0, 0, 0, 0.25);
   box-shadow: -4px -1px 33px -5px rgba(0, 0, 0, 0.25);
-  h1 {
+  h1, .logo-text {
     font-size: 20px;
     color: #4a4a4a;
     font-weight: 500;

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,7 @@
 <section class="hero is-large has-bg-img">
   <div class="hero-body">
     <div class="container">
+      <h1 class="sr-only">Abalone Analytics</h1>
     </div>
   </div>
 </section>
@@ -8,19 +9,20 @@
 <% if current_user %>
   <div class="column"></div>
   <section class="column">
-    <h1 class="has-text-centered title">
+    <h2 class="has-text-centered title">
       Your organization: <%= current_organization.name %>
-    </h1>
+    </h2>
   </section>
-  <section class="section has-text-centered">
+  <div class="section has-text-centered">
     <div class="container">
       <div class="columns">
         <div class="column"></div>
         <div class="column is-narrow">
           <div class="card">
             <div class="card-content">
-              <h2 class="subtitle">Total No. of Animals</h2>
-              <h1 class="title"><%= @animal_count %></h1>
+              <p class="subtitle">Total No. of Animals<br />
+                <span class="title"><%= @animal_count %></span>
+              </p>
             </div>
           </div>
         </div>
@@ -31,8 +33,9 @@
         <div class="column is-one-fifth">
           <div class="card">
             <div class="card-content">
-              <h2 class="subtitle">No. of Facilities</h2>
-              <h1 class="title"><%= @facility_count %></h1>
+              <p class="subtitle">No. of Facilities<br/>
+                <span class="title"><%= @facility_count %></span>
+              </p>
             </div>
           </div>
         </div>
@@ -40,13 +43,14 @@
         <div class="column is-one-fifth">
           <div class="card">
             <div class="card-content">
-              <h2 class="subtitle">No. of Cohorts</h2>
-              <h1 class="title"><%= @cohort_count %></h1>
+              <p class="subtitle">No. of Cohorts<br/>
+                <span class="title"><%= @cohort_count %></span>
+              </p>
             </div>
           </div>
         </div>
         <div class="column is-one-fifth"></div>
       </div>
     </div>
-  </section>
+  </div>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,8 +29,8 @@
     <nav class="navbar is-light" role="navigation" aria-label="main navigation">
       <div class="pl-2 flex logo">
         <%= link_to(root_path, class: 'navbar-item') do %>
-          <%= image_tag 'abalone_logo.png' %>
-          <h1 class="text-gray-900 font-bold pl-2">Abalone Analytics</h1>
+          <%= image_tag 'abalone_logo.png', alt: "Abalone Analytics - Homepage" %>
+          <span class="logo-text pl-2">Abalone Analytics</span>
         <% end %>
         <a role="button" data-target="nav-menu" class="navbar-burger" aria-label="menu" aria-expanded="false">
           <span aria-hidden="true"></span>

--- a/spec/features/home_page_statistics_spec.rb
+++ b/spec/features/home_page_statistics_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe 'Home Page Statistics' do
       sign_in user
       visit root_path
 
-      expect(page.all('h1')[1].text).to eq('Your organization: White Abalone')
+      expect(page.all('h1').count).to eq(1)
+      expect(page.find('h1').text).to eq('Abalone Analytics')
+      expect(page.find('h2').text).to eq('Your organization: White Abalone')
       expect(page.all('.card-content')[0].find('.title').text).to eq('1') # Total No. of Animals
       expect(page.all('.card-content')[1].find('.title').text).to eq('1') # No. of Facilities
       expect(page.all('.card-content')[2].find('.title').text).to eq('1') # No. of Cohorts


### PR DESCRIPTION
# Checklist:
- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #532 and #621

### Description
The logo in the navigation was an `h1` element. As we only want one `h1` on every page, and we want this to be the page title, this has been updated to a simple link.
An accessible title has been added to the homepage. This is only visible to screen readers, as sighted users can read the title on the hero banner. At the same time, the card titles and counts were inappropriately wrapped in `h2` and `h1` tags. To improve the structure of the page, these are now simple paragraphs under the 'Your organisation' header. (I originally considered making this a list, but since the cards are built from lots of `div`s I didn't want to have a bunch of list items wrapped in `div`s, as this would look pretty confusing. I also changed the `section` elements to `div`s, as sections should have a heading and I didn't think they were appropriate here.
Visually, there is no difference between the previous and current structure. There's a very small difference in the animal/cohort/facility count's font weight. For some reason Tailwind's `font-bold` class wouldn't work on these elements 🤔

### Type of change
Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
In the browser, using ANDI and VoiceOver.
