### PR TITLE
add descriptive aria labels to actions in measurement types table

### DIFF
--- a/app/views/measurement_types/index.html.erb
+++ b/app/views/measurement_types/index.html.erb
@@ -26,8 +26,16 @@
           <tr>
             <td class="px-4 py-2"><%= measurement_type.name %></td>
             <td class="px-4 py-2"><%= measurement_type.unit %></td>
-            <td class="px-4 py-2 text-primary-dark"><%= link_to image_tag("icons/edit.svg", size: 24), edit_measurement_type_path(measurement_type) %></td>
-            <td class="px-4 py-2 text-primary-dark"><%= link_to image_tag("icons/trash.svg", size: 24), measurement_type, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td class="px-4 py-2 text-primary-dark">
+              <%= link_to image_tag("icons/edit.svg", size: 24),
+              edit_measurement_type_path(measurement_type),
+              'aria-label': "Edit #{measurement_type.name}" %>
+            </td>
+            <td class="px-4 py-2 text-primary-dark">
+              <%= link_to image_tag("icons/trash.svg", size: 24),
+              measurement_type, method: :delete, data: { confirm: 'Are you sure?' },
+              'aria-label': "Delete #{measurement_type.name}" %>
+            </td>
           </tr>
         <% end %>
       </tbody>


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #559 

### Description
The 'Delete' and 'Edit' actions in the Measurement Types table did not have any labels or titles. In order to improve accessibility, I followed the recommendations on [W3.org](https://www.w3.org/WAI/GL/wiki/Using_aria-label_for_link_purpose) and added descriptive aria-labels to each link.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested with ANDI.