### PR TITLE
update shade of red to pass color contrast check

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -85,7 +85,7 @@
 
 .button-danger {
   color: white;
-  background-color: red;
+  background-color: #eb0000;
   padding: 0 11px;
   border: 1px solid #ccc;
   border-radius: 3px;


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #556

### Description
The shade of red used on the .button-danger class was too bright. To improve accessibility and get a better contrast ratio, I changed this to a darker shade of red. Now we have a contrast ratio of 4.63:1 (AA for normal text, AAA for large text according to WebAIM).

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
With WebAIM's contrast checker and with ANDI.

### Screenshots
<img width="592" alt="Screenshot 2021-04-03 at 18 59 54" src="https://user-images.githubusercontent.com/22390758/113487486-418f5700-94b0-11eb-877e-224cd39bbd66.png">

