### PR TITLE
add aria labels to facility show and location links

### DIFF
--- a/app/views/facilities/index.html.erb
+++ b/app/views/facilities/index.html.erb
@@ -33,8 +33,14 @@
           <tr>
             <td class="px-4 py-2"><%= facility.name %></td>
             <td class="px-4 py-2"><%= facility.code %></td>
-            <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', facility %></td>
-            <td class="text-primary-dark px-4 py-2"><%= link_to 'Locations', facility_locations_path(facility) %></td>
+            <td class="text-primary-dark px-4 py-2">
+              <%= link_to 'Show', facility,
+                'aria-label': "Show #{facility.name}" %>
+            </td>
+            <td class="text-primary-dark px-4 py-2">
+              <%= link_to 'Locations', facility_locations_path(facility),
+                'aria-label': "#{facility.name} location" %>
+            </td>
             <td class="px-4 py-2"><%= link_to image_tag("icons/edit.svg", size: 24), edit_facility_path(facility) %></td>
             <td class="px-4 py-2"><%= link_to image_tag("icons/trash.svg", size: 24), facility, method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>

--- a/spec/features/facilities/index_spec.rb
+++ b/spec/features/facilities/index_spec.rb
@@ -17,8 +17,10 @@ describe "When I visit the facility Index page" do
     expect(page).to have_content("Code")
     expect(page).to have_link("New Facility")
     expect(page).to have_link("Show")
+    expect(page).to have_selector("a[aria-label='Show #{facility.name}']")
     expect(page).to have_link(nil, href: edit_facility_path(facility.id))
     expect(page).to have_selector("a[data-method='delete'][href='#{facility_path(facility.id)}']")
+    expect(page).to have_selector("a[aria-label='#{facility.name} location']")
 
     expect(page).to have_content(facility.name)
     expect(page).to have_content(facility.code)


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #537 

### Description
Show and Location links in Facilities table did not have unique identifiers. To improve accessibility, I've added descriptive aria labels.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Using ANDI
