### PR TITLE
add descriptive aria label to Show links

### DIFF
--- a/app/views/enclosures/index.html.erb
+++ b/app/views/enclosures/index.html.erb
@@ -31,7 +31,7 @@
             <td class="px-4 py-2"><%= enclosure.name %></td>
             <td class="px-4 py-2"><%= enclosure.facility_name %></td>
             <td class="px-4 py-2"><%= enclosure.location_name %></td>
-            <td class="px-4 py-2 text-primary-dark"><%= link_to 'Show', enclosure %></td>
+            <td class="px-4 py-2 text-primary-dark"><%= link_to 'Show', enclosure, 'aria-label': "Show #{enclosure.name}" %></td>
             <td class="px-4 py-2"><%= link_to image_tag("icons/edit.svg", size: 24), edit_enclosure_path(enclosure) %></td>
             <td class="px-4 py-2"><%= link_to image_tag("icons/trash.svg", size: 24), enclosure, method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>

--- a/spec/features/enclosures/index_spec.rb
+++ b/spec/features/enclosures/index_spec.rb
@@ -16,6 +16,8 @@ describe "When I visit the enclosure index page" do
       expect(page).to have_content(enclosure.name)
       expect(page).to have_content(enclosure.facility_name)
       expect(page).to have_content(enclosure.location_name)
+      expect(page).to have_link('Show')
+      expect(page).to have_selector("a[aria-label='Show #{enclosure.name}']")
     end
   end
 


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #541 

### Description
"Show" links on Enclosures page didn't have unique identifiers. In order to improve accessibility, I have added descriptive aria labels.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Using ANDI
