### PR TITLE
Fix navigation links using tabindex

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
       <div class="pl-2 flex logo">
         <%= link_to(root_path, class: 'navbar-item') do %>
           <%= image_tag 'abalone_logo.png', alt: "Abalone Analytics - Homepage" %>
-          <span class="logo-text pl-2">Abalone Analytics</span>
+          <span class="logo-text pl-2" tabindex=1>Abalone Analytics</span>
         <% end %>
         <a role="button" data-target="nav-menu" class="navbar-burger" aria-label="menu" aria-expanded="false">
           <span aria-hidden="true"></span>
@@ -42,50 +42,50 @@
       <div id="nav-menu" class="pl-2 navbar-menu">
         <div class="navbar-start">
           <% if current_user %>
-            <%= link_to 'Reports', reports.root_path, class: 'navbar-item'%>
-            <%= link_to 'Facilities', facilities_path, class: 'navbar-item' %>
-            <%= link_to 'Enclosures', enclosures_path, class: 'navbar-item'%>
-            <%= link_to 'Animals', animals_path, class: 'navbar-item'%>
-            <%= link_to 'Cohorts', cohorts_path, class: 'navbar-item'%>
-            <%= link_to 'Operations', operations_path, class: 'navbar-item'%>
+            <%= link_to 'Reports', reports.root_path, class: 'navbar-item', tabindex: 2 %>
+            <%= link_to 'Facilities', facilities_path, class: 'navbar-item', tabindex: 3 %>
+            <%= link_to 'Enclosures', enclosures_path, class: 'navbar-item', tabindex: 4 %>
+            <%= link_to 'Animals', animals_path, class: 'navbar-item', tabindex: 5 %>
+            <%= link_to 'Cohorts', cohorts_path, class: 'navbar-item', tabindex: 6 %>
+            <%= link_to 'Operations', operations_path, class: 'navbar-item', tabindex: 7 %>
             <div class="navbar-item has-dropdown is-hoverable">
-              <a class="navbar-link">
+              <a class="navbar-link" tabindex=8>
                 Uploads
               </a>
               <div class="navbar-dropdown">
-                <%= link_to 'Data Import', new_measurement_path, class: 'navbar-item'%>
-                <%= link_to 'CSV Uploads', csv_index_path, class: 'navbar-item' %>
-                <%= link_to 'Files List', file_uploads_path, class: 'navbar-item'%>
-                <%= link_to 'Upload a file', new_file_upload_path, class: 'navbar-item'%>
+                <%= link_to 'Data Import', new_measurement_path, class: 'navbar-item', tabindex: 9 %>
+                <%= link_to 'CSV Uploads', csv_index_path, class: 'navbar-item', tabindex: 10 %>
+                <%= link_to 'Files List', file_uploads_path, class: 'navbar-item', tabindex: 11 %>
+                <%= link_to 'Upload a file', new_file_upload_path, class: 'navbar-item', tabindex: 12 %>
               </div>
             </div>
             <% if current_user.admin? %>
               <div class="navbar-item has-dropdown is-hoverable">
-                <a class="navbar-link">
+                <a class="navbar-link" tabindex=13>
                   Admin
                 </a>
                 <div class="navbar-dropdown">
-                  <%= link_to 'Measurement Types', measurement_types_path, class: 'navbar-item'%>
-                  <%= link_to 'Users', users_path, class: 'navbar-item'%>
+                  <%= link_to 'Measurement Types', measurement_types_path, class: 'navbar-item', tabindex: 14 %>
+                  <%= link_to 'Users', users_path, class: 'navbar-item', tabindex: 15 %>
                 </div>
               </div>
             <% end %>
           <% end %>
           <div class="navbar-item has-dropdown is-hoverable">
-            <a class="navbar-link">
+            <a class="navbar-link" tabindex=16>
               More
             </a>
 
             <div class="navbar-dropdown">
-              <%= link_to 'About', about_path, class: 'navbar-item' %>
+              <%= link_to 'About', about_path, class: 'navbar-item', tabindex: 17 %>
 
-              <a href="https://rubyforgood.org/" target="_blank" class="navbar-item">
+              <a href="https://rubyforgood.org/" target="_blank" class="navbar-item" tabindex=18>
                 Ruby for Good
               </a>
 
               <hr class="navbar-divider">
 
-              <a href="https://github.com/rubyforgood/abalone" target="_blank" class="navbar-item">
+              <a href="https://github.com/rubyforgood/abalone" target="_blank" class="navbar-item" tabindex=19>
                 Github
               </a>
             </div>
@@ -96,10 +96,10 @@
           <div class="navbar-item">
             <div class="buttons">
               <% if user_signed_in? %>
-                <%= link_to "Change password", edit_password_path(current_user), class: "button is-grey-light" %>
-                <%= link_to "Logout", destroy_user_session_path, method: :delete, class: "button is-grey-light" %>
+                <%= link_to "Change password", edit_password_path(current_user), class: "button is-grey-light", tabindex: 20 %>
+                <%= link_to "Logout", destroy_user_session_path, method: :delete, class: "button is-grey-light", tabindex: 21 %>
               <% else %>
-                <%= link_to "Login", new_user_session_path, class: "button is-grey-light button-outline-primary" %>
+                <%= link_to "Login", new_user_session_path, class: "button is-grey-light button-outline-primary", tabindex: 20 %>
               <% end %>
             </div>
           </div>

--- a/spec/features/home_page_statistics_spec.rb
+++ b/spec/features/home_page_statistics_spec.rb
@@ -11,11 +11,8 @@ RSpec.describe 'Home Page Statistics' do
     it 'When I view the home page as a visitor I see no data' do
       visit root_path
       expect(page.all('.card-content')).to be_empty
-    end
-
-    it 'When I view the home page as a visitor I see no organisation' do
-      visit root_path
-      expect(page.all('.card-content')).to be_empty
+      expect(page).to have_selector('span[tabindex=1]') # Abalone Analytics link
+      expect(page).to have_selector('a[tabindex=16]')   # More dropdown
     end
 
     it 'When I login and view the home page I see my company data' do
@@ -28,6 +25,29 @@ RSpec.describe 'Home Page Statistics' do
       expect(page.all('.card-content')[0].find('.title').text).to eq('1') # Total No. of Animals
       expect(page.all('.card-content')[1].find('.title').text).to eq('1') # No. of Facilities
       expect(page.all('.card-content')[2].find('.title').text).to eq('1') # No. of Cohorts
+
+      expect(page).to have_selector('span[tabindex=1]') # Abalone Analytics link
+      expect(page).to have_selector('a[tabindex=2]')    # Reports link
+      expect(page).to have_selector('a[tabindex=3]')    # Facilities link
+      expect(page).to have_selector('a[tabindex=4]')    # Enclosures link
+      expect(page).to have_selector('a[tabindex=5]')    # Animals link
+      expect(page).to have_selector('a[tabindex=6]')    # Cohorts link
+      expect(page).to have_selector('a[tabindex=7]')    # Operations link
+      expect(page).to have_selector('a[tabindex=8]')    # Uploads dropdown
+      expect(page).to have_selector('a[tabindex=16]')   # More dropdown
+
+      expect(page).to_not have_selector('a[tabindex=13]') # Admin dropdown
+    end
+
+    context "as an admin" do
+      let(:admin) { create(:user, :admin, organization: organization) }
+
+      it "I can see the admin dropdown" do
+        sign_in admin
+        visit root_path
+
+        expect(page).to have_selector('a[tabindex=13]') # Admin dropdown
+      end
     end
   end
 end


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #533

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

I added a `tabindex` attribute to each of the links in the navbar so you can use the keyboard to navigate to any of the links or dropdowns.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->

I added tests to `spec/features/home_page_statistics_spec.rb`