### PR TITLE
Add titles to icons on Animals page

### DIFF
--- a/app/views/animals/index.html.erb
+++ b/app/views/animals/index.html.erb
@@ -39,8 +39,8 @@
             <td class="px-4 py-2"><%= animal.cohort_name %></td>
             <td class="px-4 py-2"><%= animal.shl_number_codes(", ") %></td>
             <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', animal %></td>
-            <td class="px-4 py-2"><%= link_to image_tag("icons/edit.svg", size: 24), edit_animal_path(animal) %></td>
-            <td class="px-4 py-2"><%= link_to image_tag("icons/trash.svg", size: 24), animal, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td class="px-4 py-2"><%= link_to image_tag("icons/edit.svg", size: 24), edit_animal_path(animal), title: 'Edit' %></td>
+            <td class="px-4 py-2"><%= link_to image_tag("icons/trash.svg", size: 24), animal, title: 'Delete', method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>

--- a/spec/features/animals/index_spec.rb
+++ b/spec/features/animals/index_spec.rb
@@ -21,7 +21,9 @@ describe "When I visit the animal Index page" do
     expect(page).to have_link("New Animal")
     expect(page).to have_link("Show")
     expect(page).to have_link(nil, href: edit_animal_path(animal.id))
+    expect(page).to have_selector("a[title='Edit']")
     expect(page).to have_selector("a[data-method='delete'][href='#{animal_path(animal.id)}']")
+    expect(page).to have_selector("a[title='Delete']")
 
     expect(page).to have_content(animal.collection_year)
     expect(page).to have_content(animal.tag)


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #544

### Description
Add title to Edit and Delete icons on the Animals index page.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Feature test

