### PR TITLE
Replace bulma with tailwind on home/index

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,5 @@
-<section class="hero is-large has-bg-img">
-  <div class="hero-body">
+<section class="bg-contain lg:bg-auto flex flex-row justify-between items-stretch has-bg-img">
+  <div class="flex-grow flex-shrink-0 px-6 py-72">
     <div class="container">
       <h1 class="sr-only">Abalone Analytics</h1>
     </div>
@@ -7,49 +7,49 @@
 </section>
 
 <% if current_user %>
-  <div class="column"></div>
-  <section class="column">
-    <h2 class="has-text-centered title">
+  <div class="flex flex-row p-3"></div>
+  <section class="block">
+    <h2 class="break-words font-semibold text-title2 text-center">
       Your organization: <%= current_organization.name %>
     </h2>
   </section>
-  <div class="section has-text-centered">
+  <div class="px-5 py-12 text-center">
     <div class="container">
-      <div class="columns">
-        <div class="column"></div>
-        <div class="column is-narrow">
-          <div class="card">
-            <div class="card-content">
-              <p class="subtitle">Total No. of Animals<br />
-                <span class="title"><%= @animal_count %></span>
+      <div class="flex flex-row mb-3">
+        <div class="hidden lg:block flex-grow flex-shrink p-3 w-1/3"></div>
+        <div class="flex-grow lg:flex-none">
+          <div class="shadow">
+            <div class="p-5">
+              <p class="break-words font-normal text-title4">Total No. of Animals<br />
+                <span class="text-title2 text-center"><%= @animal_count %></span>
               </p>
             </div>
           </div>
         </div>
-        <div class="column"></div>
+        <div class="hidden lg:block flex-grow flex-shrink p-3 w-1/3"></div>
       </div>
-      <div class="columns">
-        <div class="column is-one-fifth"></div>
-        <div class="column is-one-fifth">
-          <div class="card">
-            <div class="card-content">
-              <p class="subtitle">No. of Facilities<br/>
-                <span class="title"><%= @facility_count %></span>
+      <div class="flex flex-col lg:flex-row mb-3">
+        <div class="hidden lg:block flex-grow flex-shrink p-3 w-1/5"></div>
+        <div class="block flex-grow flex-shrink p-3 lg:w-1/5">
+          <div class="shadow">
+            <div class="p-5">
+              <p class="break-words font-normal text-title4">No. of Facilities<br/>
+                <span class="text-title2 text-center"><%= @facility_count %></span>
               </p>
             </div>
           </div>
         </div>
-        <div class="column is-one-fifth"></div>
-        <div class="column is-one-fifth">
-          <div class="card">
-            <div class="card-content">
-              <p class="subtitle">No. of Cohorts<br/>
-                <span class="title"><%= @cohort_count %></span>
+        <div class="hidden lg:block flex-grow flex-shrink p-3 w-1/5"></div>
+        <div class="block flex-grow flex-shrink p-3 lg:w-1/5">
+          <div class="shadow">
+            <div class="p-5">
+              <p class="break-words font-normal text-title4">No. of Cohorts<br/>
+                <span class="text-title2 text-center"><%= @cohort_count %></span>
               </p>
             </div>
           </div>
         </div>
-        <div class="column is-one-fifth"></div>
+        <div class="hidden lg:block flex-grow flex-shrink p-3 w-1/5"></div>
       </div>
     </div>
   </div>

--- a/spec/features/home_page_statistics_spec.rb
+++ b/spec/features/home_page_statistics_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Home Page Statistics' do
 
     it 'When I view the home page as a visitor I see no data' do
       visit root_path
-      expect(page.all('.card-content')).to be_empty
+      expect(page.all('.shadow')).to be_empty
       expect(page).to have_selector('span[tabindex=1]') # Abalone Analytics link
       expect(page).to have_selector('a[tabindex=16]')   # More dropdown
     end
@@ -22,9 +22,9 @@ RSpec.describe 'Home Page Statistics' do
       expect(page.all('h1').count).to eq(1)
       expect(page.find('h1').text).to eq('Abalone Analytics')
       expect(page.find('h2').text).to eq('Your organization: White Abalone')
-      expect(page.all('.card-content')[0].find('.title').text).to eq('1') # Total No. of Animals
-      expect(page.all('.card-content')[1].find('.title').text).to eq('1') # No. of Facilities
-      expect(page.all('.card-content')[2].find('.title').text).to eq('1') # No. of Cohorts
+      expect(page.all('.shadow')[0].find('.text-title2').text).to eq('1') # Total No. of Animals
+      expect(page.all('.shadow')[1].find('.text-title2').text).to eq('1') # No. of Facilities
+      expect(page.all('.shadow')[2].find('.text-title2').text).to eq('1') # No. of Cohorts
 
       expect(page).to have_selector('span[tabindex=1]') # Abalone Analytics link
       expect(page).to have_selector('a[tabindex=2]')    # Reports link

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   theme: {
     boxShadow: {
+      default: "0 2px 3px rgb(10 10 10 / 10%), 0 0 0 1px rgb(10 10 10 / 10%)",
       sm: "0 4px 10px rgba(60,106,139,0.15)",
     },
     container: {
@@ -11,6 +12,7 @@ module.exports = {
       title1: "2.5rem",
       title2: "2.25rem",
       title3: "1.875rem",
+      title4: "1.25rem",
       body: "1rem",
       caption: "0.875rem",
     },
@@ -27,6 +29,9 @@ module.exports = {
         "dark-light": "#eee",
         "caption-light": "#757586",
         "caption-dark": "#ACACC1",
+      },
+      spacing: {
+        "72": "18rem",
       },
     },
   },


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- [ ] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->

Contributes to #466

### Description
Replaces Bulma classes with TailwindCSS classes in views/home/index.html.erb. I tried to change the style as little as possible.

### Type of change

* New feature (non-breaking change which adds functionality)

### Screenshots
**Desktop**
<img width="1429" alt="image" src="https://user-images.githubusercontent.com/4965672/117523495-f1efef80-af75-11eb-9af8-eaf8b881f250.png">

**414 x 786**
![localhost_3000_(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/4965672/117523541-31b6d700-af76-11eb-92df-89b9e4f38f31.png)

**768 x 1024**
![localhost_3000_(iPad)](https://user-images.githubusercontent.com/4965672/117523614-996d2200-af76-11eb-87cc-13f33c90c48f.png)

**1024 x 1366**
![localhost_3000_(iPad Pro)](https://user-images.githubusercontent.com/4965672/117523677-e224db00-af76-11eb-8bbb-6424e5948485.png)


