### PR TITLE
Fix width of edit/delete links in tables

### DIFF
--- a/app/views/animals/index.html.erb
+++ b/app/views/animals/index.html.erb
@@ -39,8 +39,8 @@
             <td class="px-4 py-2"><%= animal.cohort_name %></td>
             <td class="px-4 py-2"><%= animal.shl_number_codes(", ") %></td>
             <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', animal %></td>
-            <td class="px-4 py-2"><%= link_to image_tag("icons/edit.svg", size: 24), edit_animal_path(animal), title: 'Edit' %></td>
-            <td class="px-4 py-2"><%= link_to image_tag("icons/trash.svg", size: 24), animal, title: 'Delete', method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_animal_path(animal), title: 'Edit' %></td>
+            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), animal, title: 'Delete', method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -50,8 +50,8 @@
             </td>
             <td class="px-4 py-2"><%= cohort.enclosure&.name %></td>
             <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', cohort %></td>
-            <td class="px-4 py-2"><%= link_to image_tag("icons/edit.svg", size: 24), edit_cohort_path(cohort) %></td>
-            <td class="px-4 py-2"><%= link_to image_tag("icons/trash.svg", size: 24), cohort, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_cohort_path(cohort) %></td>
+            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), cohort, method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/enclosures/index.html.erb
+++ b/app/views/enclosures/index.html.erb
@@ -32,8 +32,8 @@
             <td class="px-4 py-2"><%= enclosure.facility_name %></td>
             <td class="px-4 py-2"><%= enclosure.location_name %></td>
             <td class="px-4 py-2 text-primary-dark"><%= link_to 'Show', enclosure, 'aria-label': "Show #{enclosure.name}" %></td>
-            <td class="px-4 py-2"><%= link_to image_tag("icons/edit.svg", size: 24), edit_enclosure_path(enclosure) %></td>
-            <td class="px-4 py-2"><%= link_to image_tag("icons/trash.svg", size: 24), enclosure, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_enclosure_path(enclosure) %></td>
+            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), enclosure, method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/facilities/index.html.erb
+++ b/app/views/facilities/index.html.erb
@@ -41,13 +41,13 @@
               <%= link_to 'Locations', facility_locations_path(facility),
                 'aria-label': "#{facility.name} location" %>
             </td>
-            <td class="px-4 py-2">
-              <%= link_to image_tag("icons/edit.svg", size: 24), 
+            <td class="px-4 py-2 w-12">
+              <%= link_to image_tag("icons/edit.svg"),
                 edit_facility_path(facility),
                 'aria-label': "Edit #{facility.name}" %>
             </td>
-            <td class="px-4 py-2">
-              <%= link_to image_tag("icons/trash.svg", size: 24),
+            <td class="px-4 py-2 w-12">
+              <%= link_to image_tag("icons/trash.svg"),
                 facility, method: :delete, data: { confirm: 'Are you sure?' },
                 'aria-label': "Delete #{facility.name}" %>
             </td>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -31,8 +31,8 @@
             <td class="px-4 py-2"><%= location.name %></td>
             <td class="px-4 py-2"><%= location.facility_name %></td>
             <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', facility_location_path(@facility, location) %></td>
-            <td class="px-4 py-2"><%= link_to image_tag("icons/edit.svg", size: 24), edit_facility_location_path(@facility, location) %></td>
-            <td class="px-4 py-2"><%= link_to image_tag("icons/trash.svg", size: 24), facility_location_path(@facility, location), method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_facility_location_path(@facility, location) %></td>
+            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), facility_location_path(@facility, location), method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -55,8 +55,8 @@
               <td class="px-4 py-2"><%= enclosure.facility_name %></td>
               <td class="px-4 py-2"><%= enclosure.location_name %></td>
               <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', enclosure %></td>
-              <td class="px-4 py-2"><%= link_to image_tag("icons/edit.svg", size: 24), edit_enclosure_path(enclosure) %></td>
-              <td class="px-4 py-2"><%= link_to image_tag("icons/trash.svg", size: 24), enclosure, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+              <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_enclosure_path(enclosure) %></td>
+              <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), enclosure, method: :delete, data: { confirm: 'Are you sure?' } %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/measurement_types/index.html.erb
+++ b/app/views/measurement_types/index.html.erb
@@ -17,7 +17,7 @@
         <tr class="border">
           <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase">Name</th>
           <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase">Unit</th>
-          <th colspan="3"></th>
+          <th colspan="2"></th>
         </tr>
       </thead>
 
@@ -26,13 +26,13 @@
           <tr>
             <td class="px-4 py-2"><%= measurement_type.name %></td>
             <td class="px-4 py-2"><%= measurement_type.unit %></td>
-            <td class="px-4 py-2 text-primary-dark">
-              <%= link_to image_tag("icons/edit.svg", size: 24),
+            <td class="px-4 py-2 text-primary-dark w-12">
+              <%= link_to image_tag("icons/edit.svg"),
               edit_measurement_type_path(measurement_type),
               'aria-label': "Edit #{measurement_type.name}" %>
             </td>
-            <td class="px-4 py-2 text-primary-dark">
-              <%= link_to image_tag("icons/trash.svg", size: 24),
+            <td class="px-4 py-2 text-primary-dark w-12">
+              <%= link_to image_tag("icons/trash.svg"),
               measurement_type, method: :delete, data: { confirm: 'Are you sure?' },
               'aria-label': "Delete #{measurement_type.name}" %>
             </td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -33,15 +33,15 @@
             <td class="text-primary-dark px-4 py-2">
               <%= link_to 'Show', user, title: "Show details for #{user.email}" %>
             </td>
-            <td class="px-4 py-2">
-              <%= link_to image_tag("icons/edit.svg", size: 24), edit_user_path(user), title: "Edit user #{user.email}" %>
+            <td class="px-4 py-2 w-12">
+              <%= link_to image_tag("icons/edit.svg"), edit_user_path(user), title: "Edit user #{user.email}" %>
             </td>
-            <% unless user == current_user %>
-              <td class="px-4 py-2">
-                <%= link_to image_tag("icons/trash.svg", size: 24), user, method: :delete, data: { confirm: 'Are you sure?' },
+            <td class="px-4 py-2 w-12">
+              <% unless user == current_user %>
+                <%= link_to image_tag("icons/trash.svg"), user, method: :delete, data: { confirm: 'Are you sure?' },
                 title: "Delete user #{user.email}" %>
-              </td>
-            <% end %>
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves #681 

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Added a variable width to the edit and delete images on all the tables so these links will not be hidden when the table content size increases. Also I fixed a couple places where the table border was not showing.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### Screenshots
<img width="1419" alt="image" src="https://user-images.githubusercontent.com/4965672/119271077-948aae00-bbc5-11eb-9a2c-5f57fbc4c106.png">
