### PR TITLE
Force ssl in production. Set HSTS to expire immediately.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,8 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
+  config.ssl_options = { hsts: false }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [n/a] I have commented my code, particularly in hard-to-understand areas,
- [n/a] I have made corresponding changes to the documentation,
- [n/a] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [n/a] Title include "WIP" if work is in progress.


Resolves #704

### Description
Forces application over SSL in the production environment. Sets the HSTS header expiration to 0 for future flexibility.
   
### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Test suite and rubocop run locally and in CI

