### PR TITLE
Measurement import should ignore empty lines in the file

### DIFF
--- a/app/lib/csv_importer.rb
+++ b/app/lib/csv_importer.rb
@@ -40,7 +40,7 @@ class CsvImporter
         headers: true,
         header_converters: ->(header) { CsvImporter.header_conversion(header).to_sym },
         converters: ->(value) { value&.strip },
-        skip_lines: /^\s*$/,
+        skip_lines: /^\s*$/
       ).each do |csv_row|
         csv_row[:processed_file_id] = processed_file_id
         csv_row[:raw] = false

--- a/app/lib/csv_importer.rb
+++ b/app/lib/csv_importer.rb
@@ -39,7 +39,8 @@ class CsvImporter
         temporary_file,
         headers: true,
         header_converters: ->(header) { CsvImporter.header_conversion(header).to_sym },
-        converters: ->(value) { value&.strip }
+        converters: ->(value) { value&.strip },
+        skip_lines: /^\s*$/,
       ).each do |csv_row|
         csv_row[:processed_file_id] = processed_file_id
         csv_row[:raw] = false

--- a/spec/lib/csv_importer_spec.rb
+++ b/spec/lib/csv_importer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CsvImporter do
 
         tempfile = Tempfile.new
         tempfile.write(orginal_file)
-        5.times{ tempfile.write("\n") }
+        5.times { tempfile.write("\n") }
         tempfile.rewind
 
         file = File.read(tempfile.path)

--- a/spec/lib/csv_importer_spec.rb
+++ b/spec/lib/csv_importer_spec.rb
@@ -21,6 +21,23 @@ RSpec.describe CsvImporter do
       end
     end
 
+    context "when the csv file has extra empty lines" do
+      it "ignores the empty lines and imports the valid rows" do
+        orginal_file = File.read(Rails.root.join("spec/fixtures/files/basic_custom_measurement.csv"))
+
+        tempfile = Tempfile.new
+        tempfile.write(orginal_file)
+        5.times{ tempfile.write("\n") }
+        tempfile.rewind
+
+        file = File.read(tempfile.path)
+
+        expect do
+          CsvImporter.new(file, category_name, processed_file.id, organization).call
+        end.to change { Measurement.count }.by 6
+      end
+    end
+
     context "when there are errors importing a row" do
       it "does not import any record" do
         file = File.read(Rails.root.join("spec", "fixtures", "files", "basic_custom_measurement_invalid.csv"))


### PR DESCRIPTION
Resolves #725

### Description
This change adds a parameter to the CSV parser that tells it to skip blank lines.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Added a new test to CsvImporterSpec

