### PR TITLE
Add how to run the test suite to getting-started doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ rake db:create
 rake db:migrate
 rake db:seed
 ```
+**Run Test Suite**    
+```
+bundle exec rake
+```
+
+**Run Webserver for Abalone**    
 
 Webpack dependencies can be rebuilt on command with `bin/webpack`. Alternatively you can run `bin/webpack-dev-server` in another terminal window. This will effectively run `bin/webpack` for you whenever files change.
 
@@ -68,6 +74,7 @@ rake jobs:clear
 ### Direct SQL Reporting
 
 This application uses a modified implementation of the [Blazer](https://github.com/ankane/blazer) gem to provide direct SQL access with data scoped to an organizational level. This requires some setup to use in your development environment. See the [instructions for setting this up locally](https://github.com/rubyforgood/abalone/wiki/Abalone-Analytics-Blazer-Reporting#development-environment) to get started.
+
 
 ## Docker
 


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- [x] I have performed a self-review of my own code,
- [n/a] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [n/a] I have added tests that prove my fix is effective or that my feature works,
- [n/a] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [n/a] Title include "WIP" if work is in progress.

-->

Resolves #733

### Description
Documentation change:     
This change adds how to run the ruby test suite for abalone to the getting-started section of the main README.md.
This is helpful information for setting up and validating a development environment before making changes.


### Type of change
* Documentation update

### How Has This Been Tested?

Worked through the Getting-Started steps through 'Prerequisites' and 'Setup'.
Started PostgreSQL
Then followed the added Test suite step `bundle exec rake`
All tests passed with this output:
```
Finished in 8.74 seconds (files took 4.78 seconds to load)
151 examples, 0 failures

Coverage report generated for RSpec to ../abalone/coverage. 2134 / 2256 LOC (94.59%) covered.
```

--
Let me know if this change could be accepted (or rejected) or
needs some additional changes to be approved and merged.

Thank you,
DC
