### PR TITLE
Show all imported data on processed_file#show page

### DIFF
--- a/app/controllers/file_uploads_controller.rb
+++ b/app/controllers/file_uploads_controller.rb
@@ -27,6 +27,7 @@ class FileUploadsController < ApplicationController
     @processed_file = ProcessedFile.find(params[:id])
     record_class = CsvImporter::CATEGORIES.find { |v| v == @processed_file.category }.constantize
     @headers = record_class::HEADERS.keys.map(&:downcase)
+    @row_values = record_class::ROW_VALUES.values.map(&:downcase)
     @records = record_class.where(processed_file_id: @processed_file.id)
 
     respond_to do |format|

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -9,6 +9,9 @@ class Measurement < ApplicationRecord
   validates :subject_type, presence: true, inclusion: { in: %w(Cohort Enclosure Animal) }
   validates :value, presence: true
 
+  delegate :name, to: :measurement_type, prefix: true, allow_nil: true
+  delegate :name, to: :measurement_event, prefix: true, allow_nil: true
+
   HEADERS = {
     DATE: "date",
     SUBJECT_TYPE: "subject_type",
@@ -19,6 +22,29 @@ class Measurement < ApplicationRecord
     COHORT_NAME: "cohort_name",
     TAG: 'tag'
   }.freeze
+
+  ROW_VALUES = {
+    DATE: "date",
+    SUBJECT_TYPE: "subject_type",
+    MEASUREMENT_TYPE: "measurement_type_name",
+    VALUE: "value",
+    MEASUREMENT_EVENT: "measurement_event_name",
+    ENCLOSURE_NAME: "enclosure_name",
+    COHORT_NAME: "cohort_name",
+    TAG: 'animal_tag'
+  }.freeze
+
+  def cohort_name
+    subject.is_a?(Cohort) ? subject.name : nil
+  end
+
+  def enclosure_name
+    subject.is_a?(Enclosure) ? subject.name : nil
+  end
+
+  def animal_tag
+    subject.is_a?(Animal) ? subject.tag : nil
+  end
 
   # The below code is unstable. This is retrofitting the values from the seeded CSV
   # In reality, for instance, the subject would not always be a enclosure

--- a/app/views/file_uploads/show.html.erb
+++ b/app/views/file_uploads/show.html.erb
@@ -28,8 +28,8 @@
         <tbody>
         <%- @records.each do |record| %>
           <tr>
-            <%- @headers.each do |attr|%>
-              <td><%= record[attr] %></td>
+            <%- @row_values.each do |attr|%>
+              <td><%= record.send(attr) %></td>
             <%- end %>
           </tr>
         <% end %>

--- a/spec/features/file_upload/show_spec.rb
+++ b/spec/features/file_upload/show_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe "When I visit the File Uploads show page", type: :feature do
+  let(:user) { create(:user) }
+  let(:organization) { create(:organization) }
+
+  let!(:measurement_type1) { create(:measurement_type, organization: organization) }
+  let!(:measurement_type2) { create(:measurement_type, name: 'count', unit: 'number', organization: organization) }
+  let!(:measurement_type3) { create(:measurement_type, name: 'gonad score', unit: 'number', organization: organization) }
+  let!(:cohort) { create(:cohort, name: 'Test Cohort', organization: organization) }
+
+  let(:file) { File.read(Rails.root.join("spec/fixtures/files/basic_custom_measurement.csv")) }
+  let(:processed_file) { create(:processed_file) }
+  let(:category_name) { "Measurement" }
+
+  before do
+    sign_in user
+  end
+
+  it "shows all the values that have been imported" do
+    expect do
+      CsvImporter.new(file, category_name, processed_file.id, organization).call
+    end.to change { Measurement.count }
+
+    visit show_processed_file_path(processed_file.id)
+    expect(page).to have_content("Processed File")
+
+    within(".table thead") do
+      Measurement::HEADERS.keys.map(&:downcase).each do |header|
+        expect(page).to have_content(header)
+      end
+    end
+
+    within(".table tbody") do
+      Measurement.find_each do |measurement|
+        expect(page).to have_content(measurement.date)
+        expect(page).to have_content(measurement.subject_type)
+        expect(page).to have_content(measurement.measurement_type_name)
+        expect(page).to have_content(measurement.value)
+        expect(page).to have_content(measurement.measurement_event_name)
+
+        case measurement.subject
+        when Cohort
+          expect(measurement.cohort_name).not_to be_nil
+          expect(page).to have_content(measurement.cohort_name)
+        when Enclosure
+          expect(measurement.enclosure_name).not_to be_nil
+          expect(page).to have_content(measurement.enclosure_name)
+        else
+          expect(measurement.animal_tag).not_to be_nil
+          expect(page).to have_content(measurement.animal_tag)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- [ ] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->

Resolves #711

### Description
- Some of the values were not being shown on the `processed_file#show` page because a Measurement's `subject` is polymorphic. So I added three new model functions to find `cohort_name` if the subject is a Cohort, `enclosure_name` if the subject is an Enclosure, and `animal_tag` if the subject is an Animal
- I also added two new delegates because the previous implementation was trying to show `measurement_event` and `measurement_type` which are both objects. So the table will output `measurement_type_name` and `measurement_event_name`

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

New feature test for file_upload#show

### Screenshots
<img width="1372" alt="image" src="https://user-images.githubusercontent.com/4965672/126707060-db560112-556e-46e8-bcd5-4dff8d0d2250.png">