### PR TITLE
Add border and width to login form inputs

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -6,12 +6,12 @@
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="field form-group">
         <%= f.label :email %><br />
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "border form-control w-44" %>
       </div>
 
       <div class="field">
         <%= f.label :password %><br />
-        <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
+        <%= f.password_field :password, autocomplete: "current-password", class: "border form-control w-44" %>
       </div>
 
       <% if devise_mapping.rememberable? %>


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- [ ] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->

Resolves #709 
Resolves #710

### Description
- Add `border` to email and password inputs of the login page so they don't disappear into the background
- Add width class `w-44` to email and password inputs of the login page so that Firefox browser design matches Chrome/Safari design

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Using Chrome, Safari and Firefox browsers

### Screenshots
**Safari**

<img width="851" alt="image" src="https://user-images.githubusercontent.com/4965672/127022667-4974ebaa-d179-4dd7-8db8-c25de073f1dc.png">

**Chrome**

<img width="897" alt="image" src="https://user-images.githubusercontent.com/4965672/127022935-66823ef0-7b53-4f76-9a32-5f89b0a60af1.png">

**Firefox**

<img width="818" alt="image" src="https://user-images.githubusercontent.com/4965672/127022843-3ee0a3ab-f850-4468-8027-c6ca995a915d.png">


