### PR TITLE
Fix nil warning for tests be adding an enclosure to cohort

### DIFF
--- a/spec/features/cohorts/show_spec.rb
+++ b/spec/features/cohorts/show_spec.rb
@@ -9,6 +9,10 @@ describe "When I visit the cohort Show page" do
 
   it "Then I see information of a specific cohort" do
     cohort = create(:cohort)
+    enclosure = create(:enclosure)
+
+    cohort.enclosure = enclosure
+    cohort.save
 
     visit cohort_path(cohort)
 
@@ -16,7 +20,7 @@ describe "When I visit the cohort Show page" do
       expect(page).to have_content cohort.name
       expect(page).to have_content cohort.female_tag
       expect(page).to have_content cohort.male_tag
-      expect(page).to have_content cohort.enclosure&.name
+      expect(page).to have_content cohort.enclosure.name
     end
   end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->

Resolves #708 

 (fix or feature that would cause existing functionality to not 
work as expected)
* This change requires a documentation update
* Documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->

This is a fix for the test in feature/cohorts/show_spec . Before the tests were complaining because cohort.enclosure&.name was nil, so there was no point in checking. I added an enclosure to the cohort so that we could check if the name shows up on the page. 

