### PR TITLE
#550 : add scope="col" and header

### DIFF
--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -24,11 +24,11 @@
     <table class="table-auto w-full border">
       <thead>
         <tr class="border">
-          <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase">Name</th>
-          <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase">Female</th>
-          <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase">Male</th>
-          <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase">Enclosure</th>
-          <th colspan="3"></th>
+          <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase" scope="col">Name</th>
+          <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase" scope="col">Female</th>
+          <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase" scope="col">Male</th>
+          <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase" scope="col">Enclosure</th>
+          <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase" colspan="3" scope="col">Actions</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
Sorry for my english.

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

Resolves #550 <!--fill issue number-->

### Description
I added the scope attribute to the <th> element for screenreaders and filled the empty header.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I used the same tool to check accessibility which is ANDI. The alert message is no longer there. 

### Screenshots
![screen550](https://user-images.githubusercontent.com/84066080/135090139-cb1cf7cc-38b1-4078-ba01-b9c835be30c3.png)
