### PR TITLE
#549 add aria-label on show links

### DIFF
--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -50,7 +50,7 @@
               <% end %>
             </td>
             <td class="px-4 py-2"><%= cohort.enclosure&.name %></td>
-            <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', cohort %></td>
+            <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', cohort, 'aria-label' => "Show #{cohort.name}" %></td>
             <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_cohort_path(cohort) %></td>
             <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), cohort, method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>


### PR DESCRIPTION
Sorry for my english.

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

Resolves #549 <!--fill issue number-->

### Description
I added an aria-label attribute on links to not overload the view for the common use.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I used the same tool to check accessibility which is ANDI. The alert message is no longer there. 

### Screenshots
![screen553](https://user-images.githubusercontent.com/84066080/135092318-1a084932-f131-4335-b3cf-cec115f53946.png)

