### PR TITLE
#545 add aria-label attribute on show links

### DIFF
--- a/app/views/animals/index.html.erb
+++ b/app/views/animals/index.html.erb
@@ -38,7 +38,7 @@
             <td class="px-4 py-2"><%= animal.collection_year %></td>
             <td class="px-4 py-2"><%= animal.cohort_name %></td>
             <td class="px-4 py-2"><%= animal.shl_number_codes(", ") %></td>
-            <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', animal %></td>
+            <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', animal, 'aria-label' => "Show #{animal.tag}" %></td>
             <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_animal_path(animal), title: 'Edit' %></td>
             <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), animal, title: 'Delete', method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>


### PR DESCRIPTION
Sorry for my english.

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

Resolves #545 <!--fill issue number-->

### Description
I added an aria-label attribute with the tag of the animal on links to not overload the view for the common use.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I used the same tool to check accessibility which is ANDI. The alert message is no longer there. 

### Screenshots
![screen545](https://user-images.githubusercontent.com/84066080/135094390-b6ab8bd6-1b7d-4771-9172-8407dbf6a5fe.png)

