### PR TITLE
#540 add aria-label on links

### DIFF
--- a/app/views/enclosures/index.html.erb
+++ b/app/views/enclosures/index.html.erb
@@ -32,8 +32,8 @@
             <td class="px-4 py-2"><%= enclosure.facility_name %></td>
             <td class="px-4 py-2"><%= enclosure.location_name %></td>
             <td class="px-4 py-2 text-primary-dark"><%= link_to 'Show', enclosure, 'aria-label': "Show #{enclosure.name}" %></td>
-            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_enclosure_path(enclosure) %></td>
-            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), enclosure, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_enclosure_path(enclosure), 'aria-label': "Edit #{enclosure.name}" %></td>
+            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), enclosure, 'aria-label': "Delete #{enclosure.name}", method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>


### PR DESCRIPTION
Sorry for my english.

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

Resolves #540 <!--fill issue number-->

### Description
I added an aria-label attribute on links to not overload the view for the common use. I don't have problem with icons on firefox and brave web browsers.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I used the same tool to check accessibility which is ANDI. The alert message is no longer there. 

### Screenshots
![screen540-2](https://user-images.githubusercontent.com/84066080/135098736-6745963b-fed6-4260-9bab-496c2983cce4.png)
![screen540-1](https://user-images.githubusercontent.com/84066080/135098750-d6bf4c12-54ea-47e9-971f-9b20193db952.png)


