### PR TITLE
#553 add scope="col" and header

### DIFF
--- a/app/views/file_uploads/csv_index.html.erb
+++ b/app/views/file_uploads/csv_index.html.erb
@@ -14,11 +14,11 @@
       </colgroup>
       <thead>
       <tr class="border">
-        <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase">User</th>
-        <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase">File</th>
-        <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase">Created At</th>
-        <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase"></th>
-        <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase">Status</th>
+        <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase" scope="col">User</th>
+        <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase" scope="col">File</th>
+        <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase" scope="col">Created At</th>
+        <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase" scope="col">Error</th>
+        <th class="text-sm text-caption-light font-medium px-4 py-2 uppercase" scope="col">Status</th>
       </tr>
       </thead>
 


### PR DESCRIPTION
Sorry for my english.

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

Resolves #553 <!--fill issue number-->

### Description
I added the scope attribute to the <th> element for screenreaders and filled the empty header.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I used the same tool to check accessibility which is ANDI. The alert message is no longer there. 

### Screenshots
![screen553](https://user-images.githubusercontent.com/84066080/135101050-4f15dc23-df8d-429c-8dfd-d3b54c828264.png)

