### PR TITLE
#548 add aria-label on links

### DIFF
--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -51,8 +51,8 @@
             </td>
             <td class="px-4 py-2"><%= cohort.enclosure&.name %></td>
             <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', cohort, 'aria-label' => "Show #{cohort.name}" %></td>
-            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_cohort_path(cohort) %></td>
-            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), cohort, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_cohort_path(cohort), 'aria-label' => "Edit #{cohort.name}" %></td>
+            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), cohort, method: :delete, data: { confirm: 'Are you sure?' }, 'aria-label' => "Delete #{cohort.name}" %></td>
           </tr>
         <% end %>
       </tbody>


### PR DESCRIPTION
Sorry for my english.

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

Resolves #548 <!--fill issue number-->

### Description
I added an aria-label attribute on links to not overload the view for the common use.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I used the same tool to check accessibility which is ANDI. The alert message is no longer there. 

### Screenshots
![screen548](https://user-images.githubusercontent.com/84066080/135275449-d711aea1-caba-4fff-93e8-375abbc4efb5.png)

