### PR TITLE
#748 add -moz-fit-content in sessions_container class

### DIFF
--- a/app/assets/stylesheets/sessions.scss
+++ b/app/assets/stylesheets/sessions.scss
@@ -10,6 +10,7 @@
     width: 60%;
     display: flex;
     height: fit-content;
+    height: -moz-fit-content;
     margin-top: 5rem;
     box-shadow: -4px -1px 33px -5px rgba(0, 0, 0, 0.10);
     &__form { 


### PR DESCRIPTION
Sorry for my english.

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

Resolves #748 <!--fill issue number-->

### Description
I added `height: -moz-fit-content` to the sessions_container class.
### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I check the view in the browser before and after the modification.

### Screenshots
Firefox before : 
![before_session](https://user-images.githubusercontent.com/84066080/135277441-5213e0a5-beda-4e3e-bddf-5f83afe4448d.png)

Firefox after :
![after_session](https://user-images.githubusercontent.com/84066080/135277497-7d475472-cdba-4f68-a4d9-df7de65bfa5d.png)

Brave (chrome based web browser) after is still the same :
![after_session_chrome](https://user-images.githubusercontent.com/84066080/135277598-756fa94e-4927-441b-bbd9-a318bdab9943.png)


