### PR TITLE
Styling : add vertical align for action buttons in the index views

### DIFF
--- a/app/views/animals/index.html.erb
+++ b/app/views/animals/index.html.erb
@@ -38,9 +38,9 @@
             <td class="px-4 py-2"><%= animal.collection_year %></td>
             <td class="px-4 py-2"><%= animal.cohort_name %></td>
             <td class="px-4 py-2"><%= animal.shl_number_codes(", ") %></td>
-            <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', animal, 'aria-label' => "Show #{animal.tag}" %></td>
-            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_animal_path(animal), title: 'Edit' %></td>
-            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), animal, title: 'Delete', method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td class="text-primary-dark px-4 py-2 align-middle"><%= link_to 'Show', animal, 'aria-label' => "Show #{animal.tag}" %></td>
+            <td class="px-4 py-2 w-12 align-middle"><%= link_to image_tag("icons/edit.svg"), edit_animal_path(animal), title: 'Edit' %></td>
+            <td class="px-4 py-2 w-12 align-middle"><%= link_to image_tag("icons/trash.svg"), animal, title: 'Delete', method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -50,9 +50,9 @@
               <% end %>
             </td>
             <td class="px-4 py-2"><%= cohort.enclosure&.name %></td>
-            <td class="text-primary-dark px-4 py-2"><%= link_to 'Show', cohort, 'aria-label' => "Show #{cohort.name}" %></td>
-            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_cohort_path(cohort) %></td>
-            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), cohort, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td class="text-primary-dark px-4 py-2 align-middle"><%= link_to 'Show', cohort, 'aria-label' => "Show #{cohort.name}" %></td>
+            <td class="px-4 py-2 w-12 align-middle"><%= link_to image_tag("icons/edit.svg"), edit_cohort_path(cohort) %></td>
+            <td class="px-4 py-2 w-12 align-middle"><%= link_to image_tag("icons/trash.svg"), cohort, method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/enclosures/index.html.erb
+++ b/app/views/enclosures/index.html.erb
@@ -31,9 +31,9 @@
             <td class="px-4 py-2"><%= enclosure.name %></td>
             <td class="px-4 py-2"><%= enclosure.facility_name %></td>
             <td class="px-4 py-2"><%= enclosure.location_name %></td>
-            <td class="px-4 py-2 text-primary-dark"><%= link_to 'Show', enclosure, 'aria-label': "Show #{enclosure.name}" %></td>
-            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/edit.svg"), edit_enclosure_path(enclosure), 'aria-label': "Edit #{enclosure.name}" %></td>
-            <td class="px-4 py-2 w-12"><%= link_to image_tag("icons/trash.svg"), enclosure, 'aria-label': "Delete #{enclosure.name}", method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <td class="px-4 py-2 text-primary-dark align-middle"><%= link_to 'Show', enclosure, 'aria-label': "Show #{enclosure.name}" %></td>
+            <td class="px-4 py-2 w-12 align-middle"><%= link_to image_tag("icons/edit.svg"), edit_enclosure_path(enclosure), 'aria-label': "Edit #{enclosure.name}" %></td>
+            <td class="px-4 py-2 w-12 align-middle"><%= link_to image_tag("icons/trash.svg"), enclosure, 'aria-label': "Delete #{enclosure.name}", method: :delete, data: { confirm: 'Are you sure?' } %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/facilities/index.html.erb
+++ b/app/views/facilities/index.html.erb
@@ -33,20 +33,20 @@
           <tr>
             <td class="px-4 py-2"><%= facility.name %></td>
             <td class="px-4 py-2"><%= facility.code %></td>
-            <td class="text-primary-dark px-4 py-2">
+            <td class="text-primary-dark px-4 py-2 align-middle">
               <%= link_to 'Show', facility,
                 'aria-label': "Show #{facility.name}" %>
             </td>
-            <td class="text-primary-dark px-4 py-2">
+            <td class="text-primary-dark px-4 py-2 align-middle">
               <%= link_to 'Locations', facility_locations_path(facility),
                 'aria-label': "#{facility.name} location" %>
             </td>
-            <td class="px-4 py-2 w-12">
+            <td class="px-4 py-2 w-12 align-middle">
               <%= link_to image_tag("icons/edit.svg"),
                 edit_facility_path(facility),
                 'aria-label': "Edit #{facility.name}" %>
             </td>
-            <td class="px-4 py-2 w-12">
+            <td class="px-4 py-2 w-12 align-middle">
               <%= link_to image_tag("icons/trash.svg"),
                 facility, method: :delete, data: { confirm: 'Are you sure?' },
                 'aria-label': "Delete #{facility.name}" %>


### PR DESCRIPTION
Sorry for my english.

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.



Resolves : nothing

### Description

Just align the actions in index views with the `align-middle` class of tailwind .

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Just looking the web browser.

### Screenshots

Before :
![enclosures](https://user-images.githubusercontent.com/84066080/135643266-ac91139d-dcdf-4e3d-944b-7664a64ad8e9.png)

After :
![enclosures2](https://user-images.githubusercontent.com/84066080/135643340-bada105b-d9cb-41fd-b2fc-bc858b7206b6.png)

