### PR TITLE
Resolves issue #724: Org-scoped Blazer queries

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,7 @@ AllCops:
     - 'db/**/*'
     - 'bin/**/*'
     - 'config/routes.rb'
+    - 'app/overrides/controllers/blazer/queries_controller_override.rb'
   # Default formatter will be used if no `-f/--format` option is given.
   DefaultFormatter: progress
   # Cop names are displayed in offense messages by default. Change behavior

--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,11 @@ end
 
 # Report builder
 gem 'reports_kit' # Replaced by blazer reporting - 1/24/21
-gem 'blazer'
+# Dependency on Blazer version 2.4.7 due to app-specific overrides living in
+# app/overrides that depend on the Blazer code at this version of the gem. Updating
+# this gem will require review of our overridden classes with changes to code in the
+# desired Blazer gem version.
+gem 'blazer', '2.4.7'
 
 # Excel and CSV support
 gem 'creek'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,7 +348,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-postgres_enum (~> 1.6)
   annotate
-  blazer
+  blazer (= 2.4.7)
   bootsnap (>= 1.1.0)
   brakeman
   byebug

--- a/app/overrides/controllers/blazer/queries_controller_override.rb
+++ b/app/overrides/controllers/blazer/queries_controller_override.rb
@@ -1,0 +1,39 @@
+Blazer::QueriesController.class_eval do
+  private
+
+  def set_queries(limit = nil)
+    # With the exception of this first statement which scopes the query to the current_user's
+    # organization, all of this code is identical to the :set_queries method from the
+    # Blazer 2.4.7 source code.
+    @queries = Blazer::Query.named
+      .joins(creator: :organization)
+      .where(creator: {organization: current_organization})
+      .select(:id, :name, :creator_id, :statement)
+    @queries = @queries.includes(:creator) if Blazer.user_class
+
+    if blazer_user && params[:filter] == "mine"
+      @queries = @queries.where(creator_id: blazer_user.id).reorder(updated_at: :desc)
+    elsif blazer_user && params[:filter] == "viewed" && Blazer.audit
+      @queries = queries_by_ids(Blazer::Audit.where(user_id: blazer_user.id).order(created_at: :desc).limit(500).pluck(:query_id).uniq)
+    else
+      @queries = @queries.limit(limit) if limit
+      @queries = @queries.active.order(:name)
+    end
+    @queries = @queries.to_a
+
+    @more = limit && @queries.size >= limit
+
+    @queries = @queries.select { |q| !q.name.to_s.start_with?("#") || q.try(:creator).try(:id) == blazer_user.try(:id) }
+
+    @queries =
+      @queries.map do |q|
+        {
+          id: q.id,
+          name: q.name,
+          creator: blazer_user && q.try(:creator) == blazer_user ? "You" : q.try(:creator).try(Blazer.user_name),
+          vars: q.variables.join(", "),
+          to_param: q.to_param
+        }
+      end
+  end
+end

--- a/blazer_reporting.md
+++ b/blazer_reporting.md
@@ -1,6 +1,8 @@
 ## Abalone Analytics Blazer Reporting
 
-This application utilizes a modified implementation of the [Blazer](https://github.com/ankane/blazer) gem to provide direct SQL access to specific tables with data scoped to an organizational level. This requires setup in both the production and development environments.
+This application utilizes a modified implementation of the [Blazer](https://github.com/ankane/blazer) gem to provide direct SQL access to specific tables with data scoped to an organizational level. Modifications to the Blazer gem are performed in app/overrides directories per [Rails documented practices](https://edgeguides.rubyonrails.org/engines.html#overriding-models-and-controllers). The Blazer gem version has been locked at 2.4.7 to ensure these overrides remain dependable.
+
+Use of the Blazer gem requires setup in both the production and development environments.
 
 ### Production Environment
 
@@ -25,10 +27,10 @@ Note: For consistency, each org credential should be named with that organizatio
 6. Attach that credential to the application.
 7. Leave the permissions blank. They will be set by the Blazer rake task.
 8. Repeat steps 5-7 for each organization in the application.
-9. In Heroku, add the environment variables for the blazer credential and all org credentials. The urls will be available under each credential in the Postgres add-on.  
-    `BLAZER_DATABASE_URL: add credential uri here`  
-    `ORG1_DATABASE_URL: add credential uri here`  
-    `ORG2_DATABASE_URL: add credential uri here`  
+9. In Heroku, add the environment variables for the blazer credential and all org credentials. The urls will be available under each credential in the Postgres add-on.
+    `BLAZER_DATABASE_URL: add credential uri here`
+    `ORG1_DATABASE_URL: add credential uri here`
+    `ORG2_DATABASE_URL: add credential uri here`
 10. Run a backup of the production database
 11. Run the Blazer rake task: `heroku run SAVE=1 rake blazer:add_database_security`.
 12. Log in as an organization user and confirm reporting is now functioning and scoped.
@@ -39,7 +41,7 @@ Note: For consistency, each org credential should be named with that organizatio
 2. In Heroku, add a credential for that organization: `org#{ID}`.
 3. Attach that credential to the application.
 4. Leave the permissions blank. They will be set by the Blazer rake task.
-5. Add the environment variable for the new credential using the uri available in the Postgres add-on.  
+5. Add the environment variable for the new credential using the uri available in the Postgres add-on.
     `ORG#{ID}_DATABASE_URL: add credential uri here`
 6. Run a backup of the production database
 7. Run the Blazer rake task: `heroku run SAVE=1 rake blazer:add_database_security`.
@@ -69,10 +71,10 @@ This process assumes initial setup, migration and seeding of a local postgres da
 4. Run the Blazer rake task: `SAVE=1 bundle exec rake blazer:add_database_security`
 5. Log in as an organization user and confirm reporting is now functioning and scoped.
 
-#### Adding a New Organization 
+#### Adding a New Organization
 
 1. Add the organization to the application (database and entry in `blazer.yml`)
-2. Add a url for the new organization to the `config/local_env.yml` file :   
+2. Add a url for the new organization to the `config/local_env.yml` file :
     `ORG#{ID}_DATABASE_URL: postgres://org#{ID}:password@localhost:5432/abalone_development`
 3. Restart your server
 4. Run the Blazer drop rake task: `SAVE=1 bundle exec rake blazer:drop_database_security`

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,13 @@ module Abalone
 
     # background processing with delayed_job
     config.active_job.queue_adapter = :delayed_job
+
+    overrides = "#{Rails.root}/app/overrides"
+    Rails.autoloaders.main.ignore(overrides)
+    config.to_prepare do
+      Dir.glob("#{overrides}/**/*_override.rb").each do |override|
+        load override
+      end
+    end
   end
 end

--- a/spec/controllers/blazer/queries_controller_spec.rb
+++ b/spec/controllers/blazer/queries_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Blazer::QueriesController, type: :controller do
+  routes { Blazer::Engine.routes }
+
+  let(:user) { FactoryBot.create(:user) }
+
+  before { sign_in(user) }
+
+  describe 'index' do
+    before do
+      FactoryBot.create_list(:blazer_query, 3, creator: user)
+      FactoryBot.create_list(:blazer_query, 7, creator: FactoryBot.create(:user))
+    end
+
+    it 'returns queries scoped to current_user\'s organization' do
+      get :index
+      queries = JSON.parse(response.body)
+      expect(queries.count).to eq(3)
+    end
+  end
+end

--- a/spec/factories/blazer/queries.rb
+++ b/spec/factories/blazer/queries.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :blazer_query, class: Blazer::Query do
+    name { 'Save the snails!' }
+    statement { "SELECT * FROM animals" }
+    creator { FactoryBot.create(:creator) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,6 +73,7 @@ RSpec.configure do |config|
 
   config.include Devise::Test::IntegrationHelpers, type: :feature
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::ControllerHelpers, type: :controller
 
   config.include FileUploadHelpers
 


### PR DESCRIPTION
Resolves #724 

Introduces an app/overrides directory for overriding engine controllers (and models)
in the conventional Rails way with class_evals loaded on application start.
(read more at https://edgeguides.rubyonrails.org/engines.html#overriding-models-and-controllers).
Override is applied to the Blazer queries_controller method :set_queries, scoping returned
queries on :home and :index actions to only those belonging to the current_user's
organization.

This change depends upon Blazer version 2.4.7, which I've now locked in the Gemfile.

This solution feels fragile on account of its reliance on the entire :set_queries method defined by the Blazer queries_controller. A change to this logic in a future version of Blazer will cause problems on gem update. A better way to override would be to add a controller method :base_query or :scoped_query to the Blazer gem in this controller for more finite overriding of this smaller method, e.g.

[# blazer/queries_controller.rb](https://github.com/ankane/blazer/blob/master/app/controllers/blazer/queries_controller.rb)
```
def set queries
  - @queries = Blazer::Query.named.select(:id, :name, :creator_id, :statement)
  + @queries = scoped_query.named.select(:id, :name, :creator_id, :statement)
  ...
end

+ def scoped_query
+   Blazer::Query
+ end
```

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
RSpec tests added to support this change.
