### PR TITLE
Remove RAILS_ENV=development from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     build: .
     image: abalone
     environment:
-      RAILS_ENV: development
       ABALONE_DATABASE_HOSTNAME: db
       DATABASE_URL: postgres://dockerpg:supersecret@db
     volumes:


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- [ ] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->

Resolves #780

### Description
A lot of the tests were failing with the following error:

```
72) When I visit the user index page As an admin user, I should have access to the users index page for my organization
      Failure/Error: expect(page).to have_content 'Users'
        expected to find text "Users" in "Blocked host: www.example.com\nTo allow requests to www.example.com, add the following to your environment configuration:\nconfig.hosts << \"www.example.com\""
      # ./spec/features/users/index_spec.rb:24:in `block (2 levels) in <top (required)>'
```

This was because the tests were being run with `RAILS_ENV=development`. I removed this environment variable from docker-compose.yml because it wasn't necessary. Now  all the tests pass when running in docker.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

All the tests pass now when using `make spec`

