### PR TITLE
Fix versions table

### DIFF
--- a/db/migrate/20211011181422_fix_versions_table.rb
+++ b/db/migrate/20211011181422_fix_versions_table.rb
@@ -1,0 +1,7 @@
+class FixVersionsTable < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :versions, "{:null=>false}"
+
+    change_column_null :versions, :item_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_08_231933) do
+ActiveRecord::Schema.define(version: 2021_10_11_181422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->

Resolves (no issue currently opened) <!--fill issue number-->

### Description
After installing the repo and running `rake db:migrate`, our group at Power all had an unexpected change to our schema of the versions table (see attached screenshot). We found that a migration had been erroneously commuted with incorrect schema. This PR fixes the versions table to match the existing schema.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Ran `db:migrate` and had unexpected schema change. Added migration to correct table to match schema, ran `db:migrate`, and verified that we no longer have unexpected schema changes.

### Screenshots

#### Unexpected schema chang
<img width="712" alt="unexpected-schema-change" src="https://user-images.githubusercontent.com/38359249/136837301-1b41f691-0d96-418f-b36a-0789259e0466.png">
e
