### PR TITLE
#869 styling enclosures form

### DIFF
--- a/app/views/enclosures/_form.html.erb
+++ b/app/views/enclosures/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: enclosure, local: true, html: { class: "w-full max-w-md" }) do |form| %>
+<%= form_with(model: enclosure, local: true, html: { class: "w-full" }) do |form| %>
   <% if enclosure.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(enclosure.errors.count, "error") %> prohibited this enclosure from being saved:</h2>
@@ -16,7 +16,7 @@
       <%= form.label :location_id, class: 'text-sm text-caption-light font-medium uppercase' %>
     </div>
     <div>
-      <%= form.collection_select :location_id, @locations, :id, :name_with_facility, include_blank: true, class: 'input mb-2' %>
+      <%= form.collection_select :location_id, @locations, :id, :name_with_facility, {}, { class: 'input w-full mb-2' }  %>
     </div>
   </div>
 
@@ -25,7 +25,7 @@
       <%= form.label :name, class: 'text-sm text-caption-light font-medium uppercase' %>
     </div>
     <div>
-      <%= form.text_field :name, class: 'input mb-2' %>
+      <%= form.text_field :name, class: 'input w-full mb-2' %>
     </div>
   </div>
 


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

Resolves #869 <!--fill issue number-->

### Description
Like [here](https://github.com/rubyforgood/abalone/pull/832) :

> HTML options must be between brackets :
> select(object, method, choices = nil, options = {}, html_options = {}, &block)
> https://apidock.com/rails/v6.0.0/ActionView/Helpers/FormOptionsHelper/select

I changed the size of elements in the form too. The input text was very small.

### Type of change

<!-- Please delete options that are not relevant. -->
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Just looking the web browser.

### Screenshots
Before :
![enclo1](https://user-images.githubusercontent.com/84066080/138271927-4d497185-facc-4782-8602-6df9f9e6949c.png)

After :
![enclo#2](https://user-images.githubusercontent.com/84066080/138271935-25828df0-ddeb-474a-b2c2-23e2bc00b138.png)


