### PR TITLE
#870 styling cohorts form

### DIFF
--- a/app/views/cohorts/_form.html.erb
+++ b/app/views/cohorts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: cohort, local: true, html: { class: "w-full max-w-md" }) do |form| %>
+<%= form_with(model: cohort, local: true, html: { class: "w-full" }) do |form| %>
   <% if cohort.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(animal.errors.count, "error") %> prohibited this cohort from being saved:</h2>
@@ -14,7 +14,7 @@
       <%= form.label :name, class: 'text-sm text-caption-light font-medium uppercase' %>
     </div>
     <div>
-      <%= form.text_field :name, class: 'input mb-2' %>
+      <%= form.text_field :name, class: 'input w-full mb-2' %>
     </div>
   </div>
   <div class="mb-2">
@@ -38,7 +38,7 @@
       <%= form.label :enclosure, class: 'text-sm text-caption-light font-medium uppercase' %>
     </div>
     <div>
-      <%= form.collection_select :enclosure_id, Enclosure.for_organization(current_organization), :id, :name, include_blank: 'Select Enclosure', class: 'input mb-2' %>
+      <%= form.collection_select :enclosure_id, Enclosure.for_organization(current_organization), :id, :name, {include_blank: 'Select Enclosure'}, {class: 'input w-full mb-2'} %>
     </div>
   </div>
   <div>


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

Resolves #870 <!--fill issue number-->

### Description
Like [here](https://github.com/rubyforgood/abalone/pull/832) :

> HTML options must be between brackets :
> select(object, method, choices = nil, options = {}, html_options = {}, &block)
> https://apidock.com/rails/v6.0.0/ActionView/Helpers/FormOptionsHelper/select

I changed the size of elements in the form too. The input text was very small.

### Type of change

<!-- Please delete options that are not relevant. -->
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Just looking the web browser.

### Screenshots
Before :
![cohort1](https://user-images.githubusercontent.com/84066080/138273959-cda40c3f-f213-4fe9-9b25-da288061ff6e.png)

After :
![cohort2](https://user-images.githubusercontent.com/84066080/138273992-483993c9-805f-48af-85c2-2a2393dc47fe.png)


