### PR TITLE
#874 Add "Select Location" default to Location field on Enclosures form

### DIFF
--- a/app/views/enclosures/_form.html.erb
+++ b/app/views/enclosures/_form.html.erb
@@ -16,7 +16,7 @@
       <%= form.label :location_id, class: 'text-sm text-caption-light font-medium uppercase' %>
     </div>
     <div>
-      <%= form.collection_select :location_id, @locations, :id, :name_with_facility, {}, { class: 'input w-full mb-2' }  %>
+      <%= form.collection_select :location_id, @locations, :id, :name_with_facility, { include_blank: 'Select Location' }, { class: 'input w-full mb-2' }  %>
     </div>
   </div>
 


### PR DESCRIPTION
Resolves #874 

### Description

Added a default value of "Select Location" on the Enclosure form

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Loaded the New Enclosure form and verified that the prompt is the default.
Verified the form can still be submitted and successfully creates the Enclosure.

### Screenshots

![Location_prompt](https://user-images.githubusercontent.com/17501514/138525642-c73af223-34d2-4b90-a21d-4bc4792e2761.png)

