### PR TITLE
#876 'Back' link on Edit Measurement Type page leads to a broken path

### DIFF
--- a/app/views/measurement_types/edit.html.erb
+++ b/app/views/measurement_types/edit.html.erb
@@ -1,6 +1,6 @@
 <section class="h-screen bg-background p-12">
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
-    <%= link_to '<< Back', measurement_type_path, class: 'text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4' %>
+    <%= link_to '<< Back', measurement_types_path, class: 'text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4' %>
     <h1 class="text-title3 mb-4">Editing Measurement Type</h1>
     <div class="facilities__form__container__body">
       <%= render 'form', measurement_type: @measurement_type %>


### PR DESCRIPTION
Resolves #876 

### Description
The 'back' link on the edit Measurement Type view was directing to a non-existent show view. Other edit pages generally redirect to the index page instead. I updated the back link to go to the Measurement Types index instead.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I clicked the 'back' link and verified it returns the user to the index.
