### PR TITLE
Name validation

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -13,6 +13,8 @@ class Cohort < ApplicationRecord
 
   belongs_to :enclosure, required: false
 
+  validates :name, presence: true, uniqueness: { scope: :organization }
+
   delegate :name, to: :enclosure, prefix: true, allow_nil: true
 
   def self.exportable_columns

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe Cohort, type: :model do
     is_expected.to have_many(:mortality_events)
   end
 
+  describe 'Cohort validations' do
+    it { should validate_uniqueness_of(:name).scoped_to(:organization) }
+    it { should validate_presence_of(:name) }
+  end
+
   include_examples 'organization presence validation'
 
   let!(:cohort) { create(:cohort) }

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -11,11 +11,17 @@ RSpec.describe Cohort, type: :model do
   end
 
   describe 'Cohort validations' do
-    it { should validate_uniqueness_of(:name).scoped_to(:organization) }
     it { should validate_presence_of(:name) }
+    it 'validates name uniquness scoped to organization' do
+      cohort_1 = create(:cohort, organization: create(:organization))
+      cohort_2 = build(:cohort, name: cohort_1.name, organization: cohort_1.organization)
+      expect(cohort_2.valid?).to eq(false)
+    end
   end
 
-  include_examples 'organization presence validation'
+  include_examples 'organization presence validation' do
+    let(:model) { described_class.new name: 'Test Name', organization: organization }
+  end
 
   let!(:cohort) { create(:cohort) }
 

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -13,9 +13,14 @@ RSpec.describe Cohort, type: :model do
   describe 'Cohort validations' do
     it { should validate_presence_of(:name) }
     it 'validates name uniquness scoped to organization' do
-      cohort_1 = create(:cohort, organization: create(:organization))
-      cohort_2 = build(:cohort, name: cohort_1.name, organization: cohort_1.organization)
-      expect(cohort_2.valid?).to eq(false)
+      cohort_org_1 = build(:cohort, organization: create(:organization))
+      expect(cohort_org_1.valid?).to eq(true)
+      create(:cohort, name: cohort_org_1.name, organization: cohort_org_1.organization)
+      # Name cannot be reused within an originization
+      expect(cohort_org_1.valid?).to eq(false)
+      # Name is only unique per oginization
+      cohort_org_2 = build(:cohort, name: cohort_org_1.name, organization: create(:organization))
+      expect(cohort_org_2.valid?).to eq(true)
     end
   end
 

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe Cohort, type: :model do
   describe 'Cohort validations' do
     it { should validate_presence_of(:name) }
     it 'validates name uniquness scoped to organization' do
-      cohort_org_1 = build(:cohort, organization: create(:organization))
-      expect(cohort_org_1.valid?).to eq(true)
-      create(:cohort, name: cohort_org_1.name, organization: cohort_org_1.organization)
+      cohort_org1 = build(:cohort, organization: create(:organization))
+      expect(cohort_org1.valid?).to eq(true)
+      create(:cohort, name: cohort_org1.name, organization: cohort_org1.organization)
       # Name cannot be reused within an originization
-      expect(cohort_org_1.valid?).to eq(false)
+      expect(cohort_org1.valid?).to eq(false)
       # Name is only unique per oginization
-      cohort_org_2 = build(:cohort, name: cohort_org_1.name, organization: create(:organization))
-      expect(cohort_org_2.valid?).to eq(true)
+      cohort_org2 = build(:cohort, name: cohort_org1.name, organization: create(:organization))
+      expect(cohort_org2.valid?).to eq(true)
     end
   end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->

Resolves #437 

### Description
Added validations to cohort model for the `:name` property. Model now test for presence of ':name', and will fail out actions that do not set or remove the attribute. ':name' was also set to be unique for the organization the cohort was created for. Multiple organizations can create cohorts with the same ':name', but the ':name' cannot be repeated for that orginization.  

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Added validation tests to `cohort_spec.rb`. Used standard shoulda-matcher tests for `:name` presence. 
Shoulda-matcher does not test for uniqueness of attributes scoped to other models, so tests were written ensuring that an instance became invalid if it was a repeated `:name`. A second expectation tests that a `:name` was not locked for other organizations. Both were tested using the boolean `.valid?` method.
