### PR TITLE
Resolves #901: Prevent the deletion of Measurement Types that have already been used in measurements

### DIFF
--- a/app/controllers/measurement_types_controller.rb
+++ b/app/controllers/measurement_types_controller.rb
@@ -30,8 +30,11 @@ class MeasurementTypesController < ApplicationController
   end
 
   def destroy
-    @measurement_type.destroy
-    redirect_to measurement_types_url, notice: 'Measurement Type was successfully destroyed.'
+    if @measurement_type.destroy
+      redirect_to measurement_types_url, notice: 'Measurement Type was successfully destroyed.'
+    else
+      redirect_to measurement_types_url, alert: @measurement_type.errors.full_messages.join(". ")
+    end
   end
 
   def edit; end

--- a/app/models/measurement_type.rb
+++ b/app/models/measurement_type.rb
@@ -1,7 +1,7 @@
 class MeasurementType < ApplicationRecord
   include OrganizationScope
 
-  has_many :measurements
+  has_many :measurements, dependent: :restrict_with_error
 
   validates :name, :unit, presence: true
 end

--- a/app/views/measurement_types/index.html.erb
+++ b/app/views/measurement_types/index.html.erb
@@ -28,14 +28,34 @@
             <td class="px-4 py-2" data-label="Name"><%= measurement_type.name %></td>
             <td class="px-4 py-2" data-label="Unit"><%= measurement_type.unit %></td>
             <td class="text-base px-4 py-2 align-middle flex items-center" data-label="Actions">
-              <%= link_to 'Show', measurement_type,
-                'aria-label': "Show #{measurement_type.name}", class: 'text-primary-dark'  %>
-              <%= link_to image_tag("icons/edit.svg"),
-              edit_measurement_type_path(measurement_type),
-              'aria-label': "Edit #{measurement_type.name}", class: 'w-5 mx-2' %>
-              <%= link_to image_tag("icons/trash.svg"),
-              measurement_type, method: :delete, data: { confirm: 'Are you sure?' },
-              'aria-label': "Delete #{measurement_type.name}", class: 'w-5 mx-2' %>
+              <%=
+                link_to(
+                  'Show',
+                  measurement_type,
+                  'aria-label': "Show #{measurement_type.name}",
+                  class: 'text-primary-dark'
+                )
+              %>
+              <%=
+                link_to(
+                  image_tag("icons/edit.svg"),
+                  edit_measurement_type_path(measurement_type),
+                  'aria-label': "Edit #{measurement_type.name}",
+                  class: 'w-5 mx-2'
+                )
+              %>
+              <% if measurement_type.measurements.empty? %>
+                <%=
+                  link_to(
+                    image_tag("icons/trash.svg"),
+                    measurement_type,
+                    method: :delete,
+                    data: { confirm: 'Are you sure?' },
+                    'aria-label': "Delete #{measurement_type.name}",
+                    class: 'trash-icon w-5 mx-2'
+                  )
+                %>
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/spec/models/measurement_type_spec.rb
+++ b/spec/models/measurement_type_spec.rb
@@ -3,9 +3,30 @@ require 'rails_helper'
 RSpec.describe MeasurementType, type: :model do
   subject(:measurement_type) { build_stubbed(:measurement_type) }
 
-  it "has associations" do
-    is_expected.to belong_to(:organization)
-    is_expected.to have_many(:measurements)
+  describe "Associations >" do
+    it "has associations" do
+      is_expected.to belong_to(:organization)
+      is_expected.to have_many(:measurements)
+    end
+
+    context "with an associated measurement" do
+      subject(:measurement_type) { create(:measurement_type) }
+
+      before do
+        create(:measurement, measurement_type: measurement_type)
+      end
+
+      it "cannot be destroyed" do
+        expect { measurement_type.destroy }
+          .not_to change(MeasurementType, :count)
+      end
+
+      it "adds an error to the measurement_type" do
+        measurement_type.destroy
+        expect(measurement_type.errors.full_messages)
+          .to eq(["Cannot delete record because dependent measurements exist"])
+      end
+    end
   end
 
   describe "Validations >" do

--- a/spec/requests/measurement_types_controller_spec.rb
+++ b/spec/requests/measurement_types_controller_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 describe MeasurementTypesController, type: :request do
   include Devise::Test::IntegrationHelpers
 
-  let(:user) { create(:user) }
-  let(:measurement_type) { create(:measurement_type, organization_id: user.organization.id) }
-  let(:measurement_type_from_another_orga) { create(:measurement_type) }
+  subject(:measurement_type) { create(:measurement_type, organization_id: user.organization.id) }
+
+  let(:user) { create(:user, :admin) }
+  let!(:measurement_type_from_another_orga) { create(:measurement_type) }
 
   before do
     sign_in user
@@ -13,13 +14,13 @@ describe MeasurementTypesController, type: :request do
 
   describe '#index' do
     it 'should have response code 302 for a non admin user' do
+      user.update(role: 'user')
+
       get measurement_types_path
       expect(response).to have_http_status(302)
     end
 
     it 'should have response code 200 for an admin user' do
-      user.update(role: 'admin')
-
       get measurement_types_path
       expect(response).to have_http_status(200)
     end
@@ -27,20 +28,18 @@ describe MeasurementTypesController, type: :request do
 
   describe '#edit' do
     it 'should have response code 302 for a non admin user' do
+      user.update(role: 'user')
+
       get edit_measurement_type_path(measurement_type.id)
       expect(response).to have_http_status(302)
     end
 
     it 'should have response code 302 for a measurement_type in another organization' do
-      user.update(role: 'admin')
-
       get edit_measurement_type_path(measurement_type_from_another_orga.id)
       expect(response).to have_http_status(302)
     end
 
     it 'should have response code 200 for a measurement_type in the current organization' do
-      user.update(role: 'admin')
-
       get edit_measurement_type_path(measurement_type.id)
       expect(response).to have_http_status(200)
     end
@@ -52,22 +51,20 @@ describe MeasurementTypesController, type: :request do
     end
 
     it 'should not have update an measurement_type if non admin user' do
+      user.update(role: 'user')
+
       put measurement_type_url(measurement_type_from_another_orga), params: { measurement_type: new_attributes }
       measurement_type_from_another_orga.reload
       expect(measurement_type_from_another_orga.name).not_to eq(new_attributes[:name])
     end
 
     it 'should not have update an measurement_type in another organization' do
-      user.update(role: 'admin')
-
       put measurement_type_url(measurement_type_from_another_orga), params: { measurement_type: new_attributes }
       measurement_type_from_another_orga.reload
       expect(measurement_type_from_another_orga.name).not_to eq(new_attributes[:name])
     end
 
     it 'should have update the measurement_type in the current organization' do
-      user.update(role: 'admin')
-
       put measurement_type_url(measurement_type), params: { measurement_type: new_attributes }
       measurement_type.reload
       expect(measurement_type.name).to eq(new_attributes[:name])
@@ -76,28 +73,35 @@ describe MeasurementTypesController, type: :request do
 
   describe '#destroy' do
     it 'should have response code 302 for a non admin user' do
-      measurement_type_from_another_orga = create(:measurement_type)
+      user.update(role: 'user')
+
       expect do
         delete measurement_type_path(measurement_type_from_another_orga)
       end.to change(MeasurementType, :count).by(0)
     end
 
     it 'should not delete a measurement_type in another organization' do
-      user.update(role: 'admin')
-
-      measurement_type_from_another_orga = create(:measurement_type)
       expect do
         delete measurement_type_path(measurement_type_from_another_orga)
       end.to change(MeasurementType, :count).by(0)
     end
 
     it 'should have delete the entity' do
-      user.update(role: 'admin')
-
       measurement_type = create(:measurement_type, organization_id: user.organization.id)
       expect do
         delete measurement_type_path(measurement_type)
       end.to change(MeasurementType, :count).by(-1)
+    end
+
+    context "with an indestructible measurement_type" do
+      before do
+        create(:measurement, measurement_type: measurement_type)
+      end
+
+      it "redirects with a flash alert" do
+        delete measurement_type_path(measurement_type)
+        expect(flash[:alert]).to eq("Cannot delete record because dependent measurements exist")
+      end
     end
   end
 end

--- a/spec/system/measurement_types/index_spec.rb
+++ b/spec/system/measurement_types/index_spec.rb
@@ -2,14 +2,13 @@ require 'rails_helper'
 
 describe "When I visit the measurement_type index page", type: :system do
   let(:user) { create(:user, role: "admin") }
+  let!(:measurement_types) { FactoryBot.create_list(:measurement_type, 3, organization: user.organization) }
 
   before do
     sign_in user
   end
 
   it "Then I see a list of measurement_types" do
-    measurement_types = FactoryBot.create_list(:measurement_type, 3, organization: user.organization)
-
     visit measurement_types_path
 
     measurement_types.each do |measurement_type|
@@ -19,12 +18,24 @@ describe "When I visit the measurement_type index page", type: :system do
   end
 
   context "As a non-admin user" do
-    it "Then I should not have access to the measurement types index page" do
+    before do
       user.update(role: "user")
+    end
 
+    it "Then I should not have access to the measurement types index page" do
       visit measurement_types_path
-
       expect(page).to have_content 'Not authorized'
+    end
+  end
+
+  context "with measurement_types with dependent measurements" do
+    before do
+      measurement_types.each { |measurement_type| create(:measurement, measurement_type: measurement_type) }
+    end
+
+    it "does not display option to delete that measurement_type" do
+      visit measurement_types_path
+      expect(page).not_to have_css(".trash-icon")
     end
   end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- [ ] I have performed a self-review of my own code,
- [ ] I have commented my code, particularly in hard-to-understand areas,
- [ ] I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->

Resolves #901  <!--fill issue number-->

### Description
With this change, measurement_types cannot be deleted if they have any dependent measurement records. In writing this code, I discovered ActiveRecord's :restrict_with_error association dependency on the model which prevents destruction at a very low level. Issues and errors resulting from a failed attempt to destroy a measurement_type are added to the object's errors for display to users and engineers working with these records. (Sidebar: we may want to circle back to exit_types and apply this same pattern for safer handling of those records outside the Controller. )

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change
New feature / Bug fix

### How Has This Been Tested?
Rspec tests have been added for measurement_type model, controller, and view
<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight 
edited element.-->
