### PR TITLE
Resolves #899: Provide Error Message for Invalid Measurement Types in import

### DIFF
--- a/app/jobs/mortality_event_job.rb
+++ b/app/jobs/mortality_event_job.rb
@@ -1,4 +1,4 @@
-class MeasurementJob < ApplicationJob
+class MortalityEventJob < ApplicationJob
   include ImportJob
 
   HEADERS = [

--- a/app/lib/file_uploader.rb
+++ b/app/lib/file_uploader.rb
@@ -1,8 +1,19 @@
 # Takes in CSV files and creates background jobs to process them
 class FileUploader
-  attr_accessor :category, :input_file, :filename, :reference, :result_message, :organization
+  attr_accessor :category,
+                :input_file,
+                :filename,
+                :reference,
+                :result_message,
+                :organization
 
-  FILE_UPLOAD_CATEGORIES = CsvImporter::CATEGORIES.map { |category| [category, category.delete(' ')] }.freeze
+  UPLOADABLE_MODELS = [
+    Measurement,
+    MortalityEvent
+  ].freeze
+  UPLOAD_JOBS = UPLOADABLE_MODELS.map { |model| "#{model}Job".constantize }
+
+  FILE_UPLOAD_CATEGORIES = UPLOADABLE_MODELS.map { |model| [model.to_s, model.to_s.gsub(" ", "")] }.freeze
 
   def initialize(category:, input_file:, organization:)
     @category = category

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -12,18 +12,6 @@ class Measurement < ApplicationRecord
   delegate :name, to: :measurement_type, prefix: true, allow_nil: true
   delegate :name, to: :measurement_event, prefix: true, allow_nil: true
 
-  HEADERS = [
-    "Date",
-    "Subject Type",
-    "Measurement Type",
-    "Value",
-    "Measurement Event",
-    "Enclosure Name",
-    "Cohort Name",
-    "Tag",
-    "Reason"
-  ].freeze
-
   # We want mortality events to be created as part of measurement file uploads, which means that if a measurement
   # file is uploaded and it has mortality events, we want to show that data as well
   def self.data_for_file(processed_file_id)

--- a/app/models/mortality_event.rb
+++ b/app/models/mortality_event.rb
@@ -6,18 +6,6 @@ class MortalityEvent < ApplicationRecord
   belongs_to :exit_type, optional: true
   belongs_to :processed_file, optional: true
 
-  HEADERS = [
-    "Date",
-    "Subject Type",
-    "Measurement Type",
-    "Value",
-    "Measurement Event",
-    "Enclosure Name",
-    "Cohort Name",
-    "Tag",
-    "Reason"
-  ].freeze
-
   def self.create_from_csv_data(attrs)
     if attrs[:measurement_type] == "animal mortality event"
       animal_attrs = attrs_for_animal(attrs)
@@ -48,6 +36,10 @@ class MortalityEvent < ApplicationRecord
     measurement_attrs[:exit_type] = ExitType.find_by(name: attrs.fetch(:reason), organization_id: attrs.fetch(:organization_id))
     measurement_attrs[:processed_file_id] = attrs.fetch(:processed_file_id)
     measurement_attrs
+  end
+
+  def self.data_for_file(processed_file_id)
+    where(processed_file_id: processed_file_id)
   end
 
   def display_data

--- a/spec/fixtures/files/basic_custom_measurement.csv
+++ b/spec/fixtures/files/basic_custom_measurement.csv
@@ -5,5 +5,3 @@ date,subject_type,measurement_type,value,measurement_event,enclosure_name,cohort
 9/01/21,Animal,gonad score,78,September Survey,Test Enclosure,Test Cohort,F-AOP,
 9/01/21,Animal,length,16,September Survey,Test Enclosure,Test Cohort,M-AOP,
 9/01/21,Animal,gonad score,46,September Survey,Test Enclosure,Test Cohort,M-AOP,
-10/01/21,Animal,animal mortality event,,October Survey,Test Enclosure,Test Cohort,M-AOP,Incidental
-10/01/21,Cohort,cohort mortality event,2,October Survey,Test Enclosure,Test Cohort,M-AOP,Incidental

--- a/spec/fixtures/files/basic_custom_measurement_invalid.csv
+++ b/spec/fixtures/files/basic_custom_measurement_invalid.csv
@@ -1,2 +1,3 @@
 date,subject_type,measurement_type,value,measurement_event,enclosure_name,cohort_name,tag,reason
 9/01/21,Cohort,count,,September Survey,Test Enclosure,Test Cohort,
+9/01/21,Cohort,invalid measurement type,24,September Survey,Test Enclosure,Test Cohort,

--- a/spec/fixtures/files/basic_custom_mortality_events.csv
+++ b/spec/fixtures/files/basic_custom_mortality_events.csv
@@ -1,0 +1,3 @@
+date,subject_type,measurement_type,value,measurement_event,enclosure_name,cohort_name,tag,reason
+10/01/21,Animal,animal mortality event,,October Survey,Test Enclosure,Test Cohort,M-AOP,Incidental
+10/01/21,Cohort,cohort mortality event,2,October Survey,Test Enclosure,Test Cohort,M-AOP,Incidental

--- a/spec/jobs/concerns/import_job.rb
+++ b/spec/jobs/concerns/import_job.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 shared_examples_for "import job" do
-  let(:local_sample_data_filepath) { Rails.root.join("db", "sample_data_files", described_class.category.underscore, filename) }
+  let(:local_sample_data_filepath) { Rails.root.join("db", "sample_data_files", described_class.target_model.to_s.underscore, filename) }
   let(:sample_csv_text) { File.read(local_sample_data_filepath, encoding: 'bom|utf-8') }
   let(:temporary_file) { create(:temporary_file, contents: sample_csv_text) }
   let(:perform_job) { described_class.perform_now(temporary_file, filename, organization) }
@@ -47,11 +47,11 @@ shared_examples_for "import job" do
 
   it "imports record into db" do
     instance = described_class.new
-    record_count_before = instance.category.constantize.count
+    record_count_before = instance.target_model.count
 
-    expect { instance.perform(temporary_file, filename, organization) }.to change { instance.category.constantize.count }
+    expect { instance.perform(temporary_file, filename, organization) }.to change { instance.target_model.count }
 
-    record_count_after = instance.category.constantize.count
+    record_count_after = instance.target_model.count
     expect(
       record_count_before < record_count_after
     ).to eq(true)

--- a/spec/lib/csv_importer_spec.rb
+++ b/spec/lib/csv_importer_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe CsvImporter do
+  subject(:csv_importer) do
+    CsvImporter.new(target_model, file, processed_file.id, organization)
+  end
+
+  let(:target_model) { Measurement }
   let!(:organization) { create(:organization) }
   let!(:measurement_type1) { create(:measurement_type, organization: organization) }
   let!(:measurement_type2) { create(:measurement_type, name: 'count', unit: 'number', organization: organization) }
@@ -10,95 +15,83 @@ RSpec.describe CsvImporter do
 
   describe "#process" do
     let(:processed_file) { create(:processed_file, organization: organization) }
-    let(:category_name) { "Measurement" }
 
     context "when csv file is perfect" do
-      it "imports all the Measurement records" do
-        file = File.read(Rails.root.join("spec/fixtures/files/basic_custom_measurement.csv"))
+      context "with Measurement records" do
+        let(:file) { File.read(Rails.root.join("spec/fixtures/files/basic_custom_measurement.csv")) }
 
-        expect do
-          CsvImporter.new(file, category_name, processed_file.id, organization).call
-        end.to change { Measurement.count }.by 6
+        it "imports all the Measurement records" do
+          expect { csv_importer.call }
+            .to change { Measurement.count }
+            .by(6)
+        end
       end
 
-      it "imports all the Mortality Event records" do
-        file = File.read(Rails.root.join("spec/fixtures/files/basic_custom_measurement.csv"))
+      context "with MortalityEvent records" do
+        let(:target_model) { MortalityEvent }
+        let(:file) { File.read(Rails.root.join("spec/fixtures/files/basic_custom_mortality_events.csv")) }
 
-        expect do
-          CsvImporter.new(file, category_name, processed_file.id, organization).call
-        end.to change { MortalityEvent.count }.by 2
+        it "imports all the Mortality Event records" do
+          expect { csv_importer.call }
+            .to change { MortalityEvent.count }
+            .by(2)
+        end
       end
     end
 
     context "when the csv file has extra empty lines" do
+      let(:file) do
+        File.read(Rails.root.join("spec/fixtures/files/basic_custom_measurement.csv"))
+            .concat("\n\n\n\n\n")
+      end
+
       it "ignores the empty lines and imports the valid rows" do
-        orginal_file = File.read(Rails.root.join("spec/fixtures/files/basic_custom_measurement.csv"))
-
-        tempfile = Tempfile.new
-        tempfile.write(orginal_file)
-        5.times { tempfile.write("\n") }
-        tempfile.rewind
-
-        file = File.read(tempfile.path)
-
-        expect do
-          CsvImporter.new(file, category_name, processed_file.id, organization).call
-        end.to change { Measurement.count }.by 6
+        expect { csv_importer.call }
+          .to change { Measurement.count }
+          .by(6)
       end
     end
 
     context "when there are errors importing a row" do
-      it "does not import any record" do
-        file = File.read(Rails.root.join("spec", "fixtures", "files", "basic_custom_measurement_invalid.csv"))
+      let(:file) { File.read(Rails.root.join("spec", "fixtures", "files", "basic_custom_measurement_invalid.csv")) }
 
-        expect do
-          CsvImporter.new(file, category_name, processed_file.id, organization).call
-        end.not_to change { Measurement.count }
+      it "does not import any record" do
+        expect { csv_importer.call }
+          .not_to change { Measurement.count }
       end
 
       it "provides error details" do
-        file = File.read(Rails.root.join("spec", "fixtures", "files", "basic_custom_measurement_invalid.csv"))
-        importer = CsvImporter.new(file, category_name, processed_file.id, organization)
-
-        expect do
-          importer.call
-        end.not_to change { Measurement.count }
-        expect(importer.errored?).to eq(true)
-        expect(importer.error_details.empty?).to eq(false)
+        expect { csv_importer.call }
+          .not_to change { Measurement.count }
+        expect(csv_importer.errored?).to eq(true)
+        expect(csv_importer.error_details.empty?).to eq(false)
       end
 
       it "provides error messages" do
-        file = File.read(Rails.root.join("spec", "fixtures", "files", "basic_custom_measurement_invalid.csv"))
-        importer = CsvImporter.new(file, category_name, processed_file.id, organization)
-
-        expect do
-          importer.call
-        end.not_to change { Measurement.count }
-        expect(importer.errored?).to eq(true)
-        expect(importer.error_messages.empty?).to eq(false)
-        expect(importer.error_messages.keys.length).to eq(1)
-        expect(importer.error_messages.values.length).to eq(1)
-        expect(importer.error_messages.keys.first).to eq('Row 2')
-        expect(importer.error_messages['Row 2']).to contain_exactly("Value can't be blank")
+        expect { csv_importer.call }
+          .not_to change { Measurement.count }
+        expect(csv_importer.errored?).to eq(true)
+        expect(csv_importer.error_messages['Row 2']).to contain_exactly("Value can't be blank")
+        expect(csv_importer.error_messages['Row 3']).to contain_exactly("Measurement type must exist")
       end
     end
   end
 
   describe "#process" do
     let(:processed_file) { create(:processed_file, organization: organization) }
-    let(:category_name) { "Measurement" }
     let!(:enclosure) { create(:enclosure, name: "Test Enclosure") }
 
     context "allows the upload of custom enclosure measurements (without notes)" do
       let(:file) { File.read(Rails.root.join("spec/fixtures/files/basic_custom_measurement.csv")) }
+
       it "saves the measurements" do
-        expect do
-          CsvImporter.new(file, category_name, processed_file.id, organization).call
-        end.to change { Measurement.count }.by(6)
+        expect { csv_importer.call }
+          .to change { Measurement.count }
+          .by(6)
       end
 
       it "attaches the proper info and relationships for measurements (existing enclosure)" do
-        CsvImporter.new(file, category_name, processed_file.id, organization).call
+        csv_importer.call
         e = Enclosure.where(name: "Test Enclosure").last
         measurement = e.measurements.last
         expect(measurement.value).to eq "42"
@@ -111,13 +104,13 @@ RSpec.describe CsvImporter do
       let!(:new_cohort) { create(:cohort, name: "New Cohort", enclosure: enclosure, organization: organization) }
 
       it "saves the measurements" do
-        expect do
-          CsvImporter.new(file, category_name, processed_file.id, organization).call
-        end.to change { Measurement.count }.by(1)
+        expect { csv_importer.call }
+          .to change { Measurement.count }
+          .by(1)
       end
 
       it "attaches the proper info and relationships for measurements (existing enclosure)" do
-        CsvImporter.new(file, category_name, processed_file.id, organization).call
+        csv_importer.call
         measurement = enclosure.cohort.measurements.last
         expect(measurement.value).to eq "12"
         expect(measurement.measurement_event.name).to eq "Monthly Count"

--- a/spec/models/mortality_event_spec.rb
+++ b/spec/models/mortality_event_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe MortalityEvent, :aggregate_failures, type: :model do
     it_behaves_like OrganizationScope
   end
 
+  describe ".data_for_file" do
+    let(:processed_file) { create :processed_file }
+    let!(:mortality_event) { create :mortality_event, processed_file: processed_file }
+
+    subject { described_class.data_for_file(processed_file.id) }
+
+    it { is_expected.to match_array([mortality_event]) }
+  end
+
   describe ".create_from_csv_data" do
     let(:cohort) { create(:cohort, name: "Aquarium of the Pacific location enclosure cohort", organization: organization) }
     let(:animal) { create(:animal, tag: "F-AOP", organization: organization) }

--- a/spec/system/file_upload/new_spec.rb
+++ b/spec/system/file_upload/new_spec.rb
@@ -18,14 +18,13 @@ describe "When I visit the File Uploads New page", type: :system do
 
     expect(page).to have_content("File Upload")
     expect(page).to have_content("Category")
-    expect(page).to have_select("category", with_options: CsvImporter::CATEGORIES)
+    expect(page).to have_select("category", with_options: FileUploader::UPLOADABLE_MODELS)
     expect(page).to have_content("Select up to 10 files to upload")
   end
 
   it "I can create a new file upload" do
     visit new_file_upload_path
 
-    select(CsvImporter::CATEGORIES.first, from: "Category")
     upload_file("Measurement", [valid_file])
 
     expect(page).to have_content("Successfully queued spreadsheet for import")

--- a/spec/system/file_upload/show_spec.rb
+++ b/spec/system/file_upload/show_spec.rb
@@ -29,14 +29,14 @@ describe "When I visit the File Uploads show page", type: :system do
 
   it "shows all the values that have been imported" do
     expect do
-      CsvImporter.new(file, category_name, processed_file.id, user.organization).call
+      CsvImporter.new(Measurement, file, processed_file.id, user.organization).call
     end.to change { Measurement.count + MortalityEvent.count }
 
     visit show_processed_file_path(processed_file.id)
     expect(page).to have_content("Processed File")
 
     within(".table thead") do
-      Measurement::HEADERS.each do |header|
+      MeasurementJob::HEADERS.each do |header|
         expect(page).to have_content(header)
       end
     end


### PR DESCRIPTION
Resolves #899

### Description
This change is necessarily larger than the issue description might imply.
The importing tools were already setup to provide an error message to the user when attempting to import a non-existent measurement_type for a new Measurement record. However, the import tooling had hard-coded a set of allowable measurement_types, likely at a time before Users could create their own custom measurement_types.

This change enables error messaging to Users by providing the following:
* Removes hard-coding of measurement_types
* Decouples CsvImporter from Measurements and MortalityEvents
* Separates the upload of Measurements from MortalityEvents (which now have distinct dropdown options at the ImportFile page)
* Additional expectation was added to an existing spec example in `spec/lib/csv_importer_spec.rb` to confirm that this change resolves issue #899 

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

New and existing rspec tests, as well as upload of Measurements and MortalityEvents running a local server.