### PR TITLE
Move exit_type destroy restriction from controller to model

### DIFF
--- a/app/controllers/exit_types_controller.rb
+++ b/app/controllers/exit_types_controller.rb
@@ -33,8 +33,7 @@ class ExitTypesController < ApplicationController
   end
 
   def destroy
-    if @exit_type.mortality_events.empty?
-      @exit_type.destroy
+    if @exit_type.destroy
       redirect_to exit_types_url, notice: "Exit type was successfully destroyed."
     else
       redirect_to exit_types_path, alert: 'Some mortality events are using this exit type'

--- a/app/models/exit_type.rb
+++ b/app/models/exit_type.rb
@@ -1,7 +1,7 @@
 class ExitType < ApplicationRecord
   include OrganizationScope
 
-  has_many :mortality_events
+  has_many :mortality_events, dependent: :restrict_with_error
 
   validates :name, presence: true
 end

--- a/spec/models/exit_type_spec.rb
+++ b/spec/models/exit_type_spec.rb
@@ -13,5 +13,24 @@ RSpec.describe ExitType, type: :model do
     it_behaves_like OrganizationScope
 
     it { is_expected.to validate_presence_of(:name) }
+
+    context "with an associated mortality_events" do
+      subject(:exit_type) { create(:exit_type) }
+
+      before do
+        create(:mortality_event, exit_type: exit_type)
+      end
+
+      it "cannot be destroyed" do
+        expect { exit_type.destroy }
+          .not_to change(ExitType, :count)
+      end
+
+      it "adds an error to the exit_type" do
+        exit_type.destroy
+        expect(exit_type.errors.full_messages)
+          .to eq(["Cannot delete record because dependent mortality events exist"])
+      end
+    end
   end
 end


### PR DESCRIPTION
Follow-through related to #901 

### Description
This commit moves the ExitType destroy restriction from the exit_types_controller to the model.

### Type of change
Refactor

### How Has This Been Tested?

Additional spec examples added to ExitType model