### PR TITLE
Bump blazer gem to version 2.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'reports_kit' # Replaced by blazer reporting - 1/24/21
 # app/overrides that depend on the Blazer code at this version of the gem. Updating
 # this gem will require review of our overridden classes with changes to code in the
 # desired Blazer gem version.
-gem 'blazer', '2.4.7'
+gem 'blazer', '2.5.0'
 
 # Excel and CSV support
 gem 'creek'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     ast (2.4.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
-    blazer (2.4.7)
+    blazer (2.5.0)
       activerecord (>= 5)
       chartkick (>= 3.2)
       railties (>= 5)
@@ -113,7 +113,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    chartkick (4.0.5)
+    chartkick (4.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
@@ -134,7 +134,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    errbase (0.2.1)
+    errbase (0.2.2)
     erubi (1.10.0)
     execjs (2.7.0)
     factory_bot (6.2.0)
@@ -353,7 +353,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-postgres_enum (~> 2.0)
   annotate
-  blazer (= 2.4.7)
+  blazer (= 2.5.0)
   bootsnap (>= 1.1.0)
   brakeman
   byebug

--- a/app/overrides/controllers/blazer/queries_controller_override.rb
+++ b/app/overrides/controllers/blazer/queries_controller_override.rb
@@ -4,7 +4,7 @@ Blazer::QueriesController.class_eval do
   def set_queries(limit = nil)
     # With the exception of this first statement which scopes the query to the current_user's
     # organization, all of this code is identical to the :set_queries method from the
-    # Blazer 2.4.7 source code.
+    # Blazer 2.5.0 source code.
     @queries = Blazer::Query.named
       .joins(creator: :organization)
       .where(creator: {organization: current_organization})


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [n/a] I have made corresponding changes to the documentation,
- [n/a] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [n/a] Title include "WIP" if work is in progress.

### Description
Upgrades the blazer gem to 2.5.0. Confirms that override of the set_queries method does not need any changes. This override is in place to ensure that only queries for the current organization are displayed on the Dashboard. This compliments the database constraints that allow for multi-tenancy in the application.
   
### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Existing checks pass. Blazer dashboard manually tested after upgrade.

