### PR TITLE
only allow admins to edit their own organization's measurements

### DIFF
--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -8,7 +8,9 @@ class MeasurementsController < ApplicationController
 
   def show; end
 
-  def edit; end
+  def edit
+    redirect_to measurements_path, alert: 'Not authorized to edit this measurement' unless current_org_measurement?
+  end
 
   def update
     if @measurement.update(measurement_params)
@@ -54,5 +56,9 @@ class MeasurementsController < ApplicationController
       :subject_type,
       :measurement_type_id
     ).merge(organization_id: current_organization.id)
+  end
+
+  def current_org_measurement?
+    @measurement.organization == current_organization
   end
 end

--- a/spec/requests/measurements_controller_spec.rb
+++ b/spec/requests/measurements_controller_spec.rb
@@ -43,13 +43,29 @@ describe MeasurementsController, type: :request do
   end
 
   describe '#edit', :aggregate_failures do
-    it 'should have response code 200 for admin user' do
-      measurement_id = FactoryBot.create(:measurement).id
-      user = create(:user, role: "admin")
-      sign_in user
-      get edit_measurement_path(measurement_id)
+    it 'should have response code 200 for admin user editing for own organization' do
+      my_org = FactoryBot.create(:organization, id: 1, name: "My org")
+      user = create(:user, role: "admin", organization: my_org)
+      measurement = FactoryBot.create(:measurement, organization: my_org)
 
-      expect(response).to have_http_status(:success)
+      sign_in user
+
+      get edit_measurement_path(measurement)
+
+      expect(response).to have_http_status(200)
+    end
+
+    it 'should have response code 302 for admin user editing for other organization' do
+      my_org = FactoryBot.create(:organization, id: 1, name: "My org")
+      other_org = FactoryBot.create(:organization, id: 2, name: "Other org")
+      user = create(:user, role: "admin", organization: my_org)
+      measurement = FactoryBot.create(:measurement, organization: other_org)
+
+      sign_in user
+
+      get edit_measurement_path(measurement)
+
+      expect(response).to have_http_status(302)
     end
 
     it 'should have response code 302 for non-admin user' do


### PR DESCRIPTION
Resolves #1029

### Description
Admin users are currently able to edit any organization's measurements. We want to limit this to _their own organization_. This PR introduces a new `current_org_measurement?` check and redirects the user to the measurements table if the check fails.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Updated request specs with further examples.
