### PR TITLE
Add cancel and back span helpers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,13 @@
 module ApplicationHelper
   include Pagy::Frontend
+
+  # <span>&lt;&lt; Back</span>
+  def back_span_tag
+    content_tag(:span, "<< Back")
+  end
+
+  # <span>&lt;&lt; Cancel</span>
+  def cancel_span_tag
+    content_tag(:span, "<< Cancel")
+  end
 end

--- a/app/views/animals/csv_upload.html.erb
+++ b/app/views/animals/csv_upload.html.erb
@@ -19,6 +19,6 @@
       <% end %>
     </div>
 
-    <%= link_to '<< Back', animals_path, class: 'button-outline-primary' %>
+    <%= link_to back_span_tag, animals_path, class: 'button-outline-primary' %>
   </div>
 </section>

--- a/app/views/animals/edit.html.erb
+++ b/app/views/animals/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to animals_path do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">Editing Animal</h1>

--- a/app/views/animals/new.html.erb
+++ b/app/views/animals/new.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to animals_path do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">New Animal</h1>

--- a/app/views/animals/show.html.erb
+++ b/app/views/animals/show.html.erb
@@ -4,7 +4,7 @@
     <div class="flex justify-between items-start mb-4">
       <%= link_to animals_path do %>
         <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center">
-          <span><< Back</span>
+          <%= back_span_tag %>
         </button>
       <% end %>
       <%= link_to edit_animal_path(@animal) do %>
@@ -36,7 +36,7 @@
         <div class="text-sm text-caption-light font-medium uppercase mt-2">SHL Numbers</div>
         <%= @animal.shl_number_codes(", ") %>
     </div>
-    <%= link_to '<< BACK', animals_path, class: "mr-3 mb-3 button-outline-primary" %>
+    <%= link_to back_span_tag, animals_path, class: "mr-3 mb-3 button-outline-primary" %>
     <%= link_to "Edit", edit_animal_path(@animal), class: "button-outline-primary mt-4" %>
   </div>
 </section>

--- a/app/views/cohort_imports/new.html.erb
+++ b/app/views/cohort_imports/new.html.erb
@@ -18,6 +18,6 @@
       <% end %>
     </div>
 
-    <%= link_to '<< Back', cohorts_path, class: 'button-outline-primary' %>
+    <%= link_to back_span_tag, cohorts_path, class: 'button-outline-primary' %>
   </div>
 </section>

--- a/app/views/cohorts/edit.html.erb
+++ b/app/views/cohorts/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to cohorts_path do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">Editing Cohort</h1>

--- a/app/views/cohorts/new.html.erb
+++ b/app/views/cohorts/new.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to cohorts_path do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">New Cohort</h1>

--- a/app/views/cohorts/show.html.erb
+++ b/app/views/cohorts/show.html.erb
@@ -4,7 +4,7 @@
     <div class="flex justify-between items-start mb-4">
       <%= link_to cohorts_path do %>
         <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center">
-          <span><< Back</span>
+          <%= back_span_tag %>
         </button>
       <% end %>
       <%= link_to edit_cohort_path(@cohort) do %>
@@ -30,7 +30,7 @@
         <%= link_to animal.tag, animal_path(animal) %>
       <% end %>
     </div>
-    <%= link_to '<< BACK', cohorts_path, class: "mr-3 mb-3 button-outline-primary" %>
+    <%= link_to back_span_tag, cohorts_path, class: "mr-3 mb-3 button-outline-primary" %>
     <%= link_to "Edit", edit_cohort_path(@cohort), class: "button-outline-primary mt-4" %>
   </div>
 </section>

--- a/app/views/enclosures/csv_upload.html.erb
+++ b/app/views/enclosures/csv_upload.html.erb
@@ -22,6 +22,6 @@
       <% end %>
     </div>
 
-    <%= link_to '<< Back', enclosures_path, class: 'button-outline-primary' %>
+    <%= link_to back_span_tag, enclosures_path, class: 'button-outline-primary' %>
   </div>
 </section>

--- a/app/views/enclosures/edit.html.erb
+++ b/app/views/enclosures/edit.html.erb
@@ -1,7 +1,7 @@
 <section class="h-screen p-12 bg-background">
   <div class="container px-8 py-6 mx-auto bg-white lg:max-w-xl rounded-md shadow-sm">
     <%= link_to enclosures_path, class: "inline-flex items-center py-2 mb-4 font-bold rounded text-primary-dark hover:text-primary" do %>
-      <span><< Cancel</span>
+      <%= cancel_span_tag %>
     <% end %>
     <h1 class="text-title3 mb-4">Editing Enclosure</h1>
     <div class="relative block">

--- a/app/views/enclosures/new.html.erb
+++ b/app/views/enclosures/new.html.erb
@@ -1,7 +1,7 @@
 <section class="h-screen p-12 bg-background">
   <div class="container px-8 py-6 mx-auto bg-white lg:max-w-xl rounded-md shadow-sm">
     <%= link_to enclosures_path, class: "inline-flex items-center py-2 mb-4 font-bold rounded text-primary-dark hover:text-primary" do %>
-      <span><< Cancel</span>
+      <%= cancel_span_tag %>
     <% end %>
     <h1 class="text-title3 mb-4">New Enclosure</h1>
     <div>

--- a/app/views/enclosures/show.html.erb
+++ b/app/views/enclosures/show.html.erb
@@ -3,7 +3,7 @@
     <p id="notice"><%= notice %></p>
     <div class="flex items-start justify-between mb-4">
       <%= link_to enclosures_path, class: "inline-flex items-center py-2 font-bold rounded text-primary-dark hover:text-primary" do %>
-        <span><< Back</span>
+        <%= back_span_tag %>
       <% end %>
       <%= link_to edit_enclosure_path(@enclosure), class: "inline-flex items-center px-4 py-2 font-bold text-white rounded bg-primary-dark hover:bg-primary" do %>
         <span>Edit Enclosure</span>
@@ -21,9 +21,8 @@
         <%= @enclosure.location_name %>
     </div>
 
-    <%= link_to '<< BACK', enclosures_path, class: "mr-3 mb-3 button-outline-primary" %>
+    <%= link_to back_span_tag, enclosures_path, class: "mr-3 mb-3 button-outline-primary" %>
     <%= link_to "Edit", edit_enclosure_path(@enclosure), class: "button-outline-primary mt-4" %>
 
   </div>
 </section>
-

--- a/app/views/exit_types/edit.html.erb
+++ b/app/views/exit_types/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to exit_types_path do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">Editing Exit Type</h1>

--- a/app/views/exit_types/new.html.erb
+++ b/app/views/exit_types/new.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to exit_types_path do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">New Exit Type</h1>

--- a/app/views/exit_types/show.html.erb
+++ b/app/views/exit_types/show.html.erb
@@ -4,7 +4,7 @@
     <div class="flex justify-between items-start mb-4">
       <%= link_to exit_types_path do %>
         <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center">
-          <span><< Back</span>
+          <%= back_span_tag %>
         </button>
       <% end %>
       <%= link_to edit_exit_type_path(@exit_type) do %>
@@ -22,7 +22,7 @@
       <div class="text-sm text-caption-light font-medium uppercase">Name</div>
       <%= @exit_type.name %>
     </div>
-    <%= link_to '<< BACK', exit_types_path, class: "mr-3 mb-3 button-outline-primary" %>
+    <%= link_to back_span_tag, exit_types_path, class: "mr-3 mb-3 button-outline-primary" %>
     <%= link_to "Edit", edit_exit_type_path(@exit_type), class: "button-outline-primary mt-4" %>
   </div>
 </section>

--- a/app/views/facilities/edit.html.erb
+++ b/app/views/facilities/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to facilities_path do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">Editing Facility</h1>

--- a/app/views/facilities/new.html.erb
+++ b/app/views/facilities/new.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to facilities_path do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">New Facility</h1>

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -4,7 +4,7 @@
     <div class="flex justify-between items-start mb-4">
       <%= link_to facilities_path do %>
         <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center">
-          <span><< Back</span>
+          <%= back_span_tag %>
         </button>
       <% end %>
       <%= link_to edit_facility_path(@facility) do %>

--- a/app/views/locations/edit.html.erb
+++ b/app/views/locations/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to facility_locations_path do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">Editing Location</h1>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -4,7 +4,7 @@
     <div class="flex justify-between items-start mb-4">
       <%= link_to facilities_path do %>
         <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center">
-          << Back
+          <%= back_span_tag %>
         </button>
       <% end %>
       <%= link_to new_facility_location_path(@facility) do %>

--- a/app/views/locations/new.html.erb
+++ b/app/views/locations/new.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to facility_locations_path(@facility) do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">New Location</h1>

--- a/app/views/locations/show.html.erb
+++ b/app/views/locations/show.html.erb
@@ -3,7 +3,7 @@
     <div class="flex justify-between items-start mb-4">
       <%= link_to facility_locations_path(@facility) do %>
         <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center">
-          <span><< Back</span>
+          <%= back_span_tag %>
         </button>
       <% end %>
       <%= link_to edit_facility_location_path(@facility, @location) do %>

--- a/app/views/measurement_types/edit.html.erb
+++ b/app/views/measurement_types/edit.html.erb
@@ -1,6 +1,6 @@
 <section class="h-screen bg-background p-12">
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
-    <%= link_to '<< Back', measurement_types_path, class: 'text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4' %>
+    <%= link_to back_span_tag, measurement_types_path, class: 'text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4' %>
     <h1 class="text-title3 mb-4">Editing Measurement Type</h1>
     <div class="facilities__form__container__body">
       <%= render 'form', measurement_type: @measurement_type %>

--- a/app/views/measurement_types/new.html.erb
+++ b/app/views/measurement_types/new.html.erb
@@ -4,6 +4,6 @@
     <div class="facilities__form__container__body">
       <%= render 'form', measurement_type: @measurement_type %>
     </div>
-    <%= link_to '<< Back', measurement_types_path, class: 'text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4' %>
+    <%= link_to back_span_tag, measurement_types_path, class: 'text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4' %>
   </div>
 </section>

--- a/app/views/measurement_types/show.html.erb
+++ b/app/views/measurement_types/show.html.erb
@@ -4,7 +4,7 @@
     <div class="flex justify-between items-start mb-4">
       <%= link_to measurement_types_path do %>
         <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center">
-          <span><< Back</span>
+          <%= back_span_tag %>
         </button>
       <% end %>
       <%= link_to edit_measurement_type_path(@measurement_type) do %>

--- a/app/views/measurements/edit.html.erb
+++ b/app/views/measurements/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to measurements_path do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">Editing Measurement</h1>
@@ -11,4 +11,3 @@
     </div>
   </div>
 </section>
-

--- a/app/views/measurements/show.html.erb
+++ b/app/views/measurements/show.html.erb
@@ -4,7 +4,7 @@
     <div class="flex justify-between items-start mb-4">
       <%= link_to measurements_path do %>
         <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center">
-          <span><< Back</span>
+          <%= back_span_tag %>
         </button>
       <% end %>
     </div>
@@ -27,6 +27,6 @@
       </div>
         <%= subject_name_value %>
     </div>
-    <%= link_to '<< BACK', measurements_path, class: "mr-3 mb-3 button-outline-primary" %>
+    <%= link_to back_span_tag, measurements_path, class: "mr-3 mb-3 button-outline-primary" %>
   </div>
 </section>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -27,6 +27,6 @@
         </div>
       <% end %>
     </div>
-    <%= link_to('<< Back', users_path, class: "button-outline-primary") if @user.admin? %>
+    <%= link_to(back_span_tag, users_path, class: "button-outline-primary") if @user.admin? %>
   </div>
 </section>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to users_path do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">Editing User</h1>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,7 +2,7 @@
   <div class="container lg:max-w-xl mx-auto bg-white py-6 px-8 rounded-md shadow-sm">
     <%= link_to users_path do %>
       <button class="text-primary-dark hover:text-primary font-bold py-2 rounded inline-flex items-center mb-4">
-        <span><< Cancel</span>
+        <%= cancel_span_tag %>
       </button>
     <% end %>
     <h1 class="text-title3 mb-4">New User</h1>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,7 +12,7 @@
         <%= @user.email %>
     </div>
 
-    <%= link_to '<< BACK', users_path, class: "mr-3 mb-3 button-outline-primary" %>
+    <%= link_to back_span_tag, users_path, class: "mr-3 mb-3 button-outline-primary" %>
     <%= link_to "Edit", edit_user_path(@user), class: "button-outline-primary mt-4" %>
   </div>
 </section>


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.

-->

Resolves #1120

### Description
Adds a helper for "<< Back" and "<< Cancel" button and link labels. Some of these values were inconsistent or incorrectly (if not at all) escaped, this at least keeps things consistent and easy to repeat.

Guide questions:
  - What motivated this change (if not already described in an issue)?
    - Desire to fix something on the internet somewhere/anywhere. Inconsistent text formatting once kicked my dog, couldn't stand by this time.
  - What alternative solutions did you consider?
    - find-replace/gsub text inline in all erb files.
  - What are the tradeoffs for your solution?
    - uses a extra method for something that could be hardcoded directly into the erb files.
   
List any dependencies that are required for this change. (gems, js libraries, etc.)
- None

Include anything else we should know about. -->
- Some libraries are a little out of date at the moment (nio4r), not willing to bump those without understanding the project more.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Open browser and visually verify text is present.
